### PR TITLE
Fix isolation checks when using `device_map`

### DIFF
--- a/examples/cuda_pytorch_inference_gpt2_2gpu.yaml
+++ b/examples/cuda_pytorch_inference_gpt2_2gpu.yaml
@@ -9,6 +9,8 @@ device: cuda
 
 backend:
   device_map: auto
+  initial_isolation_check: false
+  continous_isolation_check: false
 
 hydra:
   job:

--- a/examples/cuda_pytorch_inference_gpt2_2gpu.yaml
+++ b/examples/cuda_pytorch_inference_gpt2_2gpu.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - base_config # inherits from base config
+  - _self_ # for hydra 1.1 compatibility
+
+experiment_name: cuda_pytorch_inference_gpt2_2gpu
+
+model: gpt2
+device: cuda
+
+backend:
+  device_map: auto
+
+hydra:
+  job:
+    env_set:
+      CUDA_VISIBLE_DEVICES: 0,1
+  sweeper:
+    params:
+      benchmark.input_shapes.batch_size: 1,2,4

--- a/examples/gpu_pytorch_training_bert_ddp.yaml
+++ b/examples/gpu_pytorch_training_bert_ddp.yaml
@@ -15,3 +15,8 @@ benchmark:
     sequence_length: 256
   training_arguments:
     per_device_train_batch_size: 32
+
+hydra:
+  job:
+    env_set:
+      CUDA_VISIBLE_DEVICES: 0,1

--- a/examples/gpu_pytorch_training_bert_ddp.yaml
+++ b/examples/gpu_pytorch_training_bert_ddp.yaml
@@ -15,8 +15,3 @@ benchmark:
     sequence_length: 256
   training_arguments:
     per_device_train_batch_size: 32
-
-hydra:
-  job:
-    env_set:
-      CUDA_VISIBLE_DEVICES: 0,1

--- a/optimum_benchmark/backends/base.py
+++ b/optimum_benchmark/backends/base.py
@@ -82,15 +82,17 @@ class Backend(ABC):
 
     def check_initial_isolation(self) -> None:
         if self.device.type == "cuda":
-            check_no_process_is_running_on_cuda_device(self.device)
+            device_ids = {self.device.index if self.device.index is not None else 0}
+            check_no_process_is_running_on_cuda_device(device_ids)
 
     def check_continous_isolation(self) -> None:
         if self.device.type == "cuda":
             from multiprocessing import Process
 
+            device_ids = {self.device.index if self.device.index is not None else 0}
             self.isolation_thread = Process(
                 target=check_only_this_process_is_running_on_cuda_device,
-                args=(self.device, os.getpid()),
+                args=(device_ids, os.getpid()),
                 daemon=True,
             )
             self.isolation_thread.start()

--- a/optimum_benchmark/utils.py
+++ b/optimum_benchmark/utils.py
@@ -96,7 +96,7 @@ def check_no_process_is_running_on_cuda_device(device_ids: List[int]) -> None:
 
         # TODO: It would be safer to run each run of a sweep in a subprocess. Although we can trust PyTorch to clear GPU memory when asked,
         # it is not a safe assumption to make for all backends.
-        if len(pids_on_device_id) > 1 or (len(pids_on_device_id) == 1 and os.getpid() not in pids_on_device_id)::
+        if len(pids_on_device_id) > 1 or (len(pids_on_device_id) == 1 and os.getpid() not in pids_on_device_id):
             raise RuntimeError(
                 f"Expected no processes on device {device_id}, "
                 f"found {len(pids_on_device_id)} processes "

--- a/optimum_benchmark/utils.py
+++ b/optimum_benchmark/utils.py
@@ -8,7 +8,7 @@ import psutil
 import platform
 import subprocess
 import numpy as np
-from typing import Optional
+from typing import Optional, List
 from logging import getLogger
 
 
@@ -56,68 +56,12 @@ def get_cpu_ram_mb():
     return bytes_to_mega_bytes(psutil.virtual_memory().total)
 
 
-def check_no_process_is_running_on_cuda_device(device: torch.device) -> None:
+def check_no_process_is_running_on_cuda_device(device_ids: List[int]) -> None:
     """
     Raises a RuntimeError if any process is running on the given cuda device.
     """
 
-    cuda_device_id = (
-        device.index if device.index is not None else torch.cuda.current_device()
-    )
-
-    # get list of all PIDs running on nvidia devices
-    pids = [
-        int(pid)
-        for pid in subprocess.check_output(
-            ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"]
-        )
-        .decode()
-        .strip()
-        .split("\n")
-        if pid != ""
-    ]
-
-    # get list of PIDs running on cuda device_id
-    pids_on_device_id = set(
-        [
-            pid
-            for pid in pids
-            if subprocess.check_output(
-                [
-                    "nvidia-smi",
-                    f"--query-compute-apps=pid,used_memory",
-                    f"--format=csv,noheader,nounits",
-                    f"--id={cuda_device_id}",
-                ]
-            )
-            .decode()
-            .startswith(f"{pid},")
-        ]
-    )
-
-    # TODO: It would be safer to run each run of a sweep in a subprocess. Although we can trust PyTorch to clear GPU memory when asked,
-    # it is not a safe assumption to make for all backends.
-    if len(pids_on_device_id) > 1:
-        raise RuntimeError(
-            f"Expected no processes on device {cuda_device_id}, "
-            f"found {len(pids_on_device_id)} processes "
-            f"with PIDs {pids_on_device_id}."
-        )
-
-
-def check_only_this_process_is_running_on_cuda_device(
-    device: torch.device, pid
-) -> None:
-    """
-    Raises a RuntimeError if at any point in time, there is a process running
-    on the given cuda device that is not the current process.
-    """
-
-    cuda_device_id = (
-        device.index if device.index is not None else torch.cuda.current_device()
-    )
-
-    while True:
+    for device_id in device_ids:
         # get list of all PIDs running on nvidia devices
         pids = [
             int(pid)
@@ -140,7 +84,7 @@ def check_only_this_process_is_running_on_cuda_device(
                         "nvidia-smi",
                         f"--query-compute-apps=pid,used_memory",
                         f"--format=csv,noheader,nounits",
-                        f"--id={cuda_device_id}",
+                        f"--id={device_id}",
                     ]
                 )
                 .decode()
@@ -148,14 +92,64 @@ def check_only_this_process_is_running_on_cuda_device(
             ]
         )
 
-        # check if there is a process running on device_id that is not the current process
+        # TODO: It would be safer to run each run of a sweep in a subprocess. Although we can trust PyTorch to clear GPU memory when asked,
+        # it is not a safe assumption to make for all backends.
         if len(pids_on_device_id) > 1:
-            os.kill(pid, signal.SIGTERM)
             raise RuntimeError(
-                f"Expected only process {pid} on device {cuda_device_id}, "
+                f"Expected no processes on device {device_id}, "
                 f"found {len(pids_on_device_id)} processes "
                 f"with PIDs {pids_on_device_id}."
             )
+
+
+def check_only_this_process_is_running_on_cuda_device(
+    device_ids: List[int], pid
+) -> None:
+    """
+    Raises a RuntimeError if at any point in time, there is a process running
+    on the given cuda device that is not the current process.
+    """
+
+    while True:
+        # get list of all PIDs running on nvidia devices
+        pids = [
+            int(pid)
+            for pid in subprocess.check_output(
+                ["nvidia-smi", "--query-compute-apps=pid", "--format=csv,noheader"]
+            )
+            .decode()
+            .strip()
+            .split("\n")
+            if pid != ""
+        ]
+
+        for device_id in device_ids:
+            # get list of PIDs running on cuda device_id
+            pids_on_device_id = set(
+                [
+                    pid
+                    for pid in pids
+                    if subprocess.check_output(
+                        [
+                            "nvidia-smi",
+                            f"--query-compute-apps=pid,used_memory",
+                            f"--format=csv,noheader,nounits",
+                            f"--id={device_id}",
+                        ]
+                    )
+                    .decode()
+                    .startswith(f"{pid},")
+                ]
+            )
+
+            # check if there is a process running on device_id that is not the current process
+            if len(pids_on_device_id) > 1:
+                os.kill(pid, signal.SIGTERM)
+                raise RuntimeError(
+                    f"Expected only process {pid} on device {device_id}, "
+                    f"found {len(pids_on_device_id)} processes "
+                    f"with PIDs {pids_on_device_id}."
+                )
 
         # sleep for 1 second
         time.sleep(1)

--- a/optimum_benchmark/utils.py
+++ b/optimum_benchmark/utils.py
@@ -96,7 +96,7 @@ def check_no_process_is_running_on_cuda_device(device_ids: List[int]) -> None:
 
         # TODO: It would be safer to run each run of a sweep in a subprocess. Although we can trust PyTorch to clear GPU memory when asked,
         # it is not a safe assumption to make for all backends.
-        if len(pids_on_device_id) > 1:
+        if len(pids_on_device_id) > 1 or (len(pids_on_device_id) == 1 and os.getpid() not in pids_on_device_id)::
             raise RuntimeError(
                 f"Expected no processes on device {device_id}, "
                 f"found {len(pids_on_device_id)} processes "


### PR DESCRIPTION
This PR:
* Fixes the isolation checks when `device_map` is used for the pytorch backend
* avoids a call to `torch.cuda.current_device()` which may trigger an error `RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method` as it requires to initialize CUDA in a subprocess, which is sensitive to the start method.
* adds a yaml example with `device_map`