### PR TITLE
Add TensorRT execution provider to onnxruntime backend

### DIFF
--- a/gpu_requirements.txt
+++ b/gpu_requirements.txt
@@ -10,6 +10,7 @@ git+https://github.com/huggingface/diffusers.git
 # dunno why the above installs onnxruntime and not onnxruntime-gpu
 onnxruntime-gpu==1.15.1
 
+tensorrt
 omegaconf==2.3.0
 hydra-core==1.3.2
 hydra_colorlog==1.2.0

--- a/optimum_benchmark/main.py
+++ b/optimum_benchmark/main.py
@@ -62,6 +62,8 @@ class ExperimentConfig:
     device: str = MISSING
     # task
     task: str = "${infer_task:${model}, ${hub_kwargs.revision}}"
+    # Execution provider for onnxruntime (CPU, CUDA, Tensorrt)
+    execution_provider: str = "Default"
 
     # ADDITIONAL MODEL CONFIGURATION: Model revision, use_auth_token, trust_remote_code
     hub_kwargs: DictConfig = DictConfig(


### PR DESCRIPTION
With this change, we can run with TensorRT execution provider in onnxruntime backend with `execution_provider` flag. For example,`optimum-benchmark --config-dir examples --config-name onnxruntime_bert_inference device=cuda execution_provider=Tensorrt`.