### PR TITLE
Backend pytorch logging mistake when config.amp_autocast is True.

### DIFF
--- a/optimum_benchmark/backends/pytorch.py
+++ b/optimum_benchmark/backends/pytorch.py
@@ -143,7 +143,7 @@ class PyTorchBackend(Backend):
         # pytorch autocast
         if config.amp_autocast:
             LOGGER.info(
-                f"\t+ Enabling Automatic Mixed Precision with dtype: {self.amp_dtype}"
+                f"\t+ Enabling Automatic Mixed Precision with dtype: {config.amp_dtype}"
             )
         self.amp_autocast = config.amp_autocast
         self.amp_dtype = (


### PR DESCRIPTION
We should make logging for config.amp_dtype when config.amp_autocast is True since self.amp_dtype is not set yet.