### PR TITLE
Adding PEFT training support

### DIFF
--- a/cpu_requirements.txt
+++ b/cpu_requirements.txt
@@ -1,3 +1,4 @@
+# HF ecosystem
 # optimum
 optimum[onnxruntime,openvino,nncf,neural-compressor]@git+https://github.com/huggingface/optimum.git
 # accelerate
@@ -6,6 +7,8 @@ git+https://github.com/huggingface/accelerate.git
 git+https://github.com/huggingface/transformers.git
 # diffusers
 git+https://github.com/huggingface/diffusers.git
+# peft
+git+https://github.com/huggingface/peft.git
 
 # cpu backends
 neural-compressor

--- a/gpu_requirements.txt
+++ b/gpu_requirements.txt
@@ -1,3 +1,4 @@
+# HF ecosystem
 # optimum
 optimum[onnxruntime-gpu]@git+https://github.com/huggingface/optimum.git
 # accelerate
@@ -6,6 +7,8 @@ git+https://github.com/huggingface/accelerate.git
 git+https://github.com/huggingface/transformers.git
 # diffusers
 git+https://github.com/huggingface/diffusers.git
+# peft
+git+https://github.com/huggingface/peft.git
 
 # hydra
 omegaconf==2.3.0

--- a/optimum_benchmark/backends/onnxruntime/backend.py
+++ b/optimum_benchmark/backends/onnxruntime/backend.py
@@ -76,6 +76,17 @@ class ORTBackend(Backend[ORTConfig]):
                 self.load_automodel_from_config()
             else:
                 self.load_automodel_from_pretrained()
+
+            if self.config.peft_strategy is not None:
+                LOGGER.info("\t+ Applying PEFT")
+                from peft import get_peft_model
+
+                from ..peft_utils import get_peft_config_class
+
+                peft_config_class = get_peft_config_class(self.config.peft_strategy)
+                peft_config = peft_config_class(**self.config.peft_config)
+                self.pretrained_model = get_peft_model(self.pretrained_model, peft_config=peft_config)
+            # early exit because nothing of the following can be applied to training
             return
 
         ###### Inference with ORTModelForxxx ######

--- a/optimum_benchmark/backends/peft_utils.py
+++ b/optimum_benchmark/backends/peft_utils.py
@@ -1,0 +1,101 @@
+from typing import TYPE_CHECKING, Type
+
+if TYPE_CHECKING:
+    from peft import PeftConfig
+
+PEFT_TASKS_TYPES = ["SEQ_CLS", "SEQ_2_SEQ_LM", "CAUSAL_LM", "TOKEN_CLS", "QUESTION_ANS", "FEATURE_EXTRACTION"]
+
+PEFT_CONFIG = {
+    "base_model_name_or_path": None,
+    "revision": None,  # str
+    "peft_type": None,  # PeftType: can't be changed anyway
+    "task_type": None,  # TaskType: SEQ_CLS, SEQ_2_SEQ_LM, CAUSAL_LM, TOKEN_CLS, QUESTION_ANS, FEATURE_EXTRACTION
+    "inference_mode": False,
+}
+LORA_CONFIG = {
+    **PEFT_CONFIG,  # inherits from PEFT_CONFIG
+    "auto_mapping": None,  # dict
+    "r": 8,  # int
+    "target_modules": None,  # List[str] | str
+    "lora_alpha": 8,  # int
+    "lora_dropout": 0,  # float
+    "fan_in_fan_out": False,  # bool
+    "bias": "none",  # str
+    "modules_to_save": None,  # List[str]
+    "init_lora_weights": True,  # bool
+    "layers_to_transform": None,  # List[int] | int
+    "layers_pattern": None,  # str
+}
+ADA_LORA_CONFIG = {
+    **LORA_CONFIG,  # inherits from LORA_CONFIG
+    "target_r": None,  # int
+    "init_r": None,  # int
+    "tinit": None,  # int
+    "tfinal": None,  # int
+    "deltaT": None,  # int
+    "beta1": None,  # float
+    "beta2": None,  # float
+    "orth_reg_weight": None,  # float
+    "total_step": None,  # Optional[int]
+    "rank_pattern": None,  # Optional[dict]
+}
+PROMPT_TUNING_CONFIG = {
+    **PEFT_CONFIG,  # inherits from PEFT_CONFIG
+    "num_virtual_tokens": None,  # int
+    "token_dim": None,  # int
+    "num_transformer_submodules": None,  # int
+    "num_attention_heads": None,  # int
+    "num_layers": None,  # int
+}
+PREFIX_TUNING_CONFIG = {
+    **PROMPT_TUNING_CONFIG,  # inherits from PROMPT_TUNING_CONFIG
+    "encoder_hidden_size": None,  # int
+    "prefix_projection": False,  # bool
+}
+P_TUNING_CONFIG = {
+    **PROMPT_TUNING_CONFIG,  # inherits from PROMPT_TUNING_CONFIG
+    "encoder_reparameterization_type": None,  # Union[str, PromptEncoderReparameterizationType]
+    "encoder_hidden_size": None,  # int
+    "encoder_num_layers": None,  # int
+    "encoder_dropout": None,  # float
+}
+IA3_CONFIG = {
+    **PEFT_CONFIG,  # inherits from PEFT_CONFIG
+    "target_modules": None,  # List[str] | str
+    "feedforward_modules": None,  # List[str] | str
+    "fan_in_fan_out": False,  # bool
+    "modules_to_save": None,  # List[str]
+    "init_ia3_weights": True,  # bool
+}
+PEFT_CONFIGS = {
+    "lora": LORA_CONFIG,
+    "prefix_tuning": PREFIX_TUNING_CONFIG,
+    "prompt_tuning": PROMPT_TUNING_CONFIG,
+    "p_tuning": P_TUNING_CONFIG,
+    "ada_lora": ADA_LORA_CONFIG,
+    "ia3": IA3_CONFIG,
+}
+
+
+def get_peft_config_class(peft_strategy: str) -> Type["PeftConfig"]:
+    from peft import (
+        AdaLoraConfig,
+        IA3Config,
+        LoraConfig,
+        PrefixTuningConfig,
+        PromptEncoderConfig,
+        PromptLearningConfig,
+    )
+
+    if peft_strategy == "lora":
+        return LoraConfig
+    elif peft_strategy == "ada_lora":
+        return AdaLoraConfig
+    elif peft_strategy == "prompt_tuning":
+        return PromptLearningConfig
+    elif peft_strategy == "prefix_tuning":
+        return PrefixTuningConfig
+    elif peft_strategy == "p_tuning":
+        return PromptEncoderConfig
+    elif peft_strategy == "ia3":
+        return IA3Config

--- a/optimum_benchmark/backends/pytorch/backned.py
+++ b/optimum_benchmark/backends/pytorch/backned.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any, Callable, Dict, List
 
 import torch
-from optimum.bettertransformer import BetterTransformer
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 from transformers import BitsAndBytesConfig, Trainer, TrainingArguments  # GPTQConfig
@@ -70,6 +69,8 @@ class PyTorchBackend(Backend[PyTorchConfig]):
         # BetterTransformer
         if self.config.bettertransformer:
             LOGGER.info("\t+ Using optimum.bettertransformer")
+            from optimum.bettertransformer import BetterTransformer
+
             self.pretrained_model = BetterTransformer.transform(
                 self.pretrained_model,
                 keep_original_model=False,
@@ -90,6 +91,17 @@ class PyTorchBackend(Backend[PyTorchConfig]):
                     self.pretrained_model.forward,
                     **self.config.torch_compile_kwargs,
                 )
+
+        if self.config.peft_strategy is not None:
+            LOGGER.info("\t+ Applying PEFT")
+            from peft import LoraConfig, get_peft_model
+
+            if self.config.peft_strategy == "lora":
+                LOGGER.info("\t+ Processing LoRA config")
+                peft_config = LoraConfig(**self.config.peft_config)
+                self.pretrained_model = get_peft_model(self.pretrained_model, peft_config=peft_config)
+            elif self.config.peft_strategy == "prefix_tuning":
+                raise NotImplementedError("Prefix tuning is not supported yet.")
 
     def load_model_from_pretrained(self) -> None:
         if self.config.quantization_strategy == "gptq":

--- a/optimum_benchmark/backends/pytorch/config.py
+++ b/optimum_benchmark/backends/pytorch/config.py
@@ -6,6 +6,7 @@ from omegaconf import OmegaConf
 
 from ...import_utils import torch_version
 from ..config import BackendConfig
+from ..peft_utils import PEFT_CONFIGS, PEFT_TASKS_TYPES
 
 OmegaConf.register_new_resolver("device_count", lambda: len(os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",")))
 OmegaConf.register_new_resolver("is_inference", lambda benchmark_name: benchmark_name == "inference")
@@ -14,7 +15,6 @@ OmegaConf.register_new_resolver("pytorch_version", torch_version)
 DEVICE_MAPS = ["auto", "sequential"]
 AMP_DTYPES = ["bfloat16", "float16"]
 TORCH_DTYPES = ["bfloat16", "float16", "float32", "auto"]
-PEFT_TASKS_TYPES = ["SEQ_CLS", "SEQ_2_SEQ_LM", "CAUSAL_LM", "TOKEN_CLS", "QUESTION_ANS", "FEATURE_EXTRACTION"]
 
 GPTQ_CONFIG = {
     "bits": 4,
@@ -57,27 +57,6 @@ DDP_CONFIG = {
     "metrics_cfg": {},
     "local_addr": None,
 }
-LORA_CONFIG = {
-    "peft_type": None,  # PeftType: can't be changed anyway
-    "auto_mapping": None,  # dict
-    "base_model_name_or_path": None,
-    "revision": None,  # str
-    "task_type": None,  # TaskType: SEQ_CLS, SEQ_2_SEQ_LM, CAUSAL_LM, TOKEN_CLS, QUESTION_ANS, FEATURE_EXTRACTION
-    "inference_mode": False,
-    "r": 8,  # int
-    "target_modules": None,  # List[str] | str
-    "lora_alpha": 8,  # int
-    "lora_dropout": 0,  # float
-    "fan_in_fan_out": False,  # bool
-    "bias": "none",  # str
-    "modules_to_save": None,  # List[str]
-    "init_lora_weights": True,  # bool
-    "layers_to_transform": None,  # List[int] | int
-    "layers_pattern": None,  # str
-}
-PEFT_CONFIGS = {
-    "lora": LORA_CONFIG,
-}
 
 
 @dataclass
@@ -114,6 +93,7 @@ class PyTorchConfig(BackendConfig):
     use_ddp: bool = False
     ddp_config: Dict[str, Any] = field(default_factory=dict)
 
+    # peft options
     peft_strategy: Optional[str] = None
     peft_config: Dict[str, Any] = field(default_factory=dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# HF ecosystem
 # optimum
 git+https://github.com/huggingface/optimum.git
 # accelerate
@@ -6,6 +7,8 @@ git+https://github.com/huggingface/accelerate.git
 git+https://github.com/huggingface/transformers.git
 # diffusers
 git+https://github.com/huggingface/diffusers.git
+# peft
+git+https://github.com/huggingface/peft.git
 
 # hydra
 omegaconf==2.3.0

--- a/tests/configs/base_config.yaml
+++ b/tests/configs/base_config.yaml
@@ -19,6 +19,9 @@ hydra:
     # we change the working directory during the run/sweep directory
     # this is useful for saving outputs in a separate directory
     chdir: true
+    env_set:
+      # by default, let's only use one GPU to avoid errors from NVIDIA DGX Display
+      CUDA_VISIBLE_DEVICES: 0
   launcher:
     # we set the number of jobs to 2 since when using 1, joblib reuses the same process
     n_jobs: 2

--- a/tests/configs/cuda_onnxruntime_training_bert_peft.yaml
+++ b/tests/configs/cuda_onnxruntime_training_bert_peft.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - base_config # inherits from base config
+  - _self_ # for hydra 1.1 compatibility
+  - override backend: onnxruntime # override backend to onnxruntime
+  - override benchmark: training # override benchmark to training
+
+experiment_name: cuda_onnxruntime_training_bert
+
+model: hf-internal-testing/tiny-random-bert
+task: text-classification
+device: cuda
+
+benchmark:
+  dataset_shapes:
+    dataset_size: 1600
+
+backend:
+  peft_strategy: lora
+  peft_config:
+    task_type: SEQ_CLS

--- a/tests/configs/cuda_onnxruntime_training_gpt2_peft.yaml
+++ b/tests/configs/cuda_onnxruntime_training_gpt2_peft.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - base_config # inherits from base config
+  - _self_ # for hydra 1.1 compatibility
+  - override backend: onnxruntime # override backend to onnxruntime
+  - override benchmark: training # override benchmark to training
+
+experiment_name: cuda_onnxruntime_training_gpt2
+
+model: hf-internal-testing/tiny-random-gpt2
+task: text-generation
+device: cuda
+
+benchmark:
+  dataset_shapes:
+    dataset_size: 1600
+
+backend:
+  peft_strategy: lora
+  peft_config:
+    task_type: CAUSAL_LM

--- a/tests/configs/cuda_pytorch_training_bert_peft.yaml
+++ b/tests/configs/cuda_pytorch_training_bert_peft.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - base_config # inherits from base config
+  - _self_ # for hydra 1.1 compatibility
+  - override benchmark: training
+
+experiment_name: cuda_pytorch_training_bert_peft
+
+model: hf-internal-testing/tiny-random-bert
+task: text-classification
+device: cuda
+
+benchmark:
+  dataset_shapes:
+    dataset_size: 1600
+
+backend:
+  peft_strategy: lora
+  peft_config:
+    task_type: SEQ_CLS

--- a/tests/configs/cuda_pytorch_training_gpt2_peft.yaml
+++ b/tests/configs/cuda_pytorch_training_gpt2_peft.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - base_config # inherits from base config
+  - _self_ # for hydra 1.1 compatibility
+  - override benchmark: training
+
+experiment_name: cuda_pytorch_training_gpt2_peft
+
+model: hf-internal-testing/tiny-random-gpt2
+task: text-generation
+device: cuda
+
+benchmark:
+  dataset_shapes:
+    dataset_size: 1600
+
+backend:
+  peft_strategy: lora
+  peft_config:
+    task_type: CAUSAL_LM


### PR DESCRIPTION
This PR will add full PEFT library support to `pytorch` and `onnxruntime` backends.

PEFT supported startegies:
- [x] [`LoRA`](https://huggingface.co/docs/peft/package_reference/tuners#peft.LoraConfig)
- [x] `AdaLoRA`
- [x] [`P-tuning`](https://huggingface.co/docs/peft/package_reference/tuners#peft.PromptEncoderConfig)
- [x] [`Prefix tuning`](https://huggingface.co/docs/peft/main/en/package_reference/tuners#peft.PrefixTuningConfig)
- [x] [`Prompt tuning`](https://huggingface.co/docs/peft/package_reference/tuners#peft.PromptTuningConfig)
- [x] [`IA3`](https://huggingface.co/docs/peft/package_reference/tuners#peft.IA3Config)

PEFT supported backneds:
- [x] `pytorch`
- [x] `onnxruntime`