### PR TITLE
Docs: Resolve various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Also, for integer parameters like `batch_size`, one can specify a range of value
 optimum-benchmark --config-dir examples --config-name pytorch_bert -m device=cpu,cuda benchmark.input_shapes.batch_size='range(1,10,step=2)'
 ```
 
-## Reporting benchamrk results (WIP)
+## Reporting benchmark results (WIP)
 
 To aggregate the results of a benchmark (run(s) or sweep(s)), you can use the `optimum-report` command.
 
@@ -135,7 +135,7 @@ You can also reuse some components of the reporting script for your use case (ex
 ## Configurations structure
 
 You can create custom configuration files following the [examples here](examples).
-You can also use `hydra`'s [composition](https://hydra.cc/docs/0.11/tutorial/composition/) with a base configuratin ([`examples/pytorch_bert.yaml`](examples/pytorch_bert.yaml) for example) and override/define parameters.
+You can also use `hydra`'s [composition](https://hydra.cc/docs/0.11/tutorial/composition/) with a base configuration ([`examples/pytorch_bert.yaml`](examples/pytorch_bert.yaml) for example) and override/define parameters.
 
 To create a configuration that uses a `wav2vec2` model and `onnxruntime` backend, it's as easy as:
 

--- a/examples/whisper/README.md
+++ b/examples/whisper/README.md
@@ -13,7 +13,7 @@ Where `${device}` is either `cpu` or `cuda`.
 
 ## Metrics
 
-Fo this benchmark I tried to compare `whisper-base` model's throughputs (forward and generate).
+For this benchmark I tried to compare `whisper-base` model's throughputs (forward and generate).
 
 Forward throughput is measured in `samples/second` with the formula `number_processed_samples / total_time`.
 Where `number_processed_samples = batch_size * number_forward_passes` is the number of samples processed by the model in `total_time`.
@@ -23,7 +23,7 @@ Where `number_generated_tokens = batch_size * num_tokens * number_generate_passe
 
 ## Search Space
 
-To be exhaustive, I benchmarked different auto optimization configurations supported by Optimum on GPU & CPU and auto quantization configrations on CPU only.
+To be exhaustive, I benchmarked different auto optimization configurations supported by Optimum on GPU & CPU and auto quantization configurations on CPU only.
 
 I also added `benchmark.batch_size=64,128 benchmark.new_tokens=10,100` to compare behavior across different batch sizes and number of generated tokens.
 

--- a/optimum_benchmark/backends/base.py
+++ b/optimum_benchmark/backends/base.py
@@ -50,7 +50,7 @@ LOGGER = getLogger("backend")
 class Backend(Generic[BackendConfigT], ABC):
     NAME: ClassVar[str]
 
-    # instance variables withouth default values https://stackoverflow.com/a/44962662
+    # instance variables without default values https://stackoverflow.com/a/44962662
     config: BackendConfigT
     pretrained_model: Union["PreTrainedModel", "Pipeline"]
     pretrained_processor: Optional["PreTrainedProcessor"]
@@ -117,7 +117,7 @@ class Backend(Generic[BackendConfigT], ABC):
             else:
                 device_ids = list(map(int, CUDA_VISIBLE_DEVICES.split(",")))
 
-            LOGGER.info(f"\t+ Checking contineous device(s) isolation of CUDA device(s): {device_ids}")
+            LOGGER.info(f"\t+ Checking continuous device(s) isolation of CUDA device(s): {device_ids}")
             self.isolation_thread = Process(
                 target=check_only_this_process_is_running_on_cuda_device,
                 args=(device_ids, os.getpid()),

--- a/optimum_benchmark/backends/neural_compressor/backend.py
+++ b/optimum_benchmark/backends/neural_compressor/backend.py
@@ -27,7 +27,7 @@ class INCBackend(Backend[INCConfig]):
 
         self.incmodel_class = get_class(TASKS_TO_INCMODELS[self.task])
         LOGGER.info(
-            f"\t+ Infered INCModel {self.incmodel_class.__name__} for task {self.task} and model_type {self.model_type}"
+            f"\t+ Inferred INCModel {self.incmodel_class.__name__} for task {self.task} and model_type {self.model_type}"
         )
 
     def validate_device(self) -> None:

--- a/optimum_benchmark/backends/onnxruntime/backend.py
+++ b/optimum_benchmark/backends/onnxruntime/backend.py
@@ -53,7 +53,7 @@ class ORTBackend(Backend[ORTConfig]):
 
         ortmodel_name = self.ortmodel_class.__name__
         LOGGER.info(
-            f"\t+ Infered ORTModel class {ortmodel_name} for task {self.task} and model_type {self.model_type}"
+            f"\t+ Inferred ORTModel class {ortmodel_name} for task {self.task} and model_type {self.model_type}"
         )
 
     def validate_device(self) -> None:
@@ -71,7 +71,7 @@ class ORTBackend(Backend[ORTConfig]):
         self.torch_dtype = getattr(torch, self.config.torch_dtype) if self.config.torch_dtype is not None else None
 
         ###### Training with ORTModule ######
-        # ort-training is basically a different package so we might need to seperate these two backends in the future
+        # ort-training is basically a different package so we might need to separate these two backends in the future
         if not self.config.use_inference_session:
             if self.config.no_weights:
                 self.load_automodel_from_config()
@@ -114,7 +114,7 @@ class ORTBackend(Backend[ORTConfig]):
             self.export = False
         else:
             if self.config.export:
-                self.use_merged = False  # merging is handeled seperately
+                self.use_merged = False  # merging is handled separately
                 self.load_automodel_from_pretrained()  # creates automodel from pretrained
                 self.export_automodel()  # exports automodel
                 self.export = False

--- a/optimum_benchmark/backends/onnxruntime/config.py
+++ b/optimum_benchmark/backends/onnxruntime/config.py
@@ -144,7 +144,7 @@ class ORTConfig(BackendConfig):
     auto_quantization: Optional[str] = None
     auto_quantization_config: Dict[str, Any] = field(default_factory=dict)
 
-    # ort-training is basically a different package so we might need to seperate these two backends in the future
+    # ort-training is basically a different package so we might need to separate these two backends in the future
     use_inference_session: bool = "${is_inference:${benchmark.name}}"
 
     # training options

--- a/optimum_benchmark/backends/openvino/backend.py
+++ b/optimum_benchmark/backends/openvino/backend.py
@@ -24,7 +24,9 @@ class OVBackend(Backend[OVConfig]):
 
         self.ovmodel_class = get_class(TASKS_TO_OVMODEL[self.task])
         ortmodel_name = self.ovmodel_class.__name__
-        LOGGER.info(f"\t+ Inferred OVModel class {ortmodel_name} for task {self.task} and model_type {self.model_type}")
+        LOGGER.info(
+            f"\t+ Inferred OVModel class {ortmodel_name} for task {self.task} and model_type {self.model_type}"
+        )
 
     def validate_task(self) -> None:
         if self.task not in TASKS_TO_OVMODEL:

--- a/optimum_benchmark/backends/openvino/backend.py
+++ b/optimum_benchmark/backends/openvino/backend.py
@@ -24,7 +24,7 @@ class OVBackend(Backend[OVConfig]):
 
         self.ovmodel_class = get_class(TASKS_TO_OVMODEL[self.task])
         ortmodel_name = self.ovmodel_class.__name__
-        LOGGER.info(f"\t+ Infered OVModel class {ortmodel_name} for task {self.task} and model_type {self.model_type}")
+        LOGGER.info(f"\t+ Inferred OVModel class {ortmodel_name} for task {self.task} and model_type {self.model_type}")
 
     def validate_task(self) -> None:
         if self.task not in TASKS_TO_OVMODEL:

--- a/optimum_benchmark/backends/optimum_utils.py
+++ b/optimum_benchmark/backends/optimum_utils.py
@@ -245,7 +245,7 @@ def main_export(
         and not is_stable_diffusion
         and task + "-with-past" in TasksManager.get_supported_tasks_for_model_type(model_type, "onnx")
     ):
-        if original_task == "auto":  # Make -with-past the default if --task was not explicitely specified
+        if original_task == "auto":  # Make -with-past the default if --task was not explicitly specified
             task = task + "-with-past"
         else:
             logger.info(
@@ -328,7 +328,7 @@ def main_export(
         if model.config.is_encoder_decoder and task.startswith("text-generation"):
             raise ValueError(
                 f"model.config.is_encoder_decoder is True and task is `{task}`, which are incompatible. If the task was auto-inferred, please fill a bug report"
-                f"at https://github.com/huggingface/optimum, if --task was explicitely passed, make sure you selected the right task for the model,"
+                f"at https://github.com/huggingface/optimum, if --task was explicitly passed, make sure you selected the right task for the model,"
                 f" referring to `optimum.exporters.tasks.TaskManager`'s `_TASKS_TO_AUTOMODELS`."
             )
 

--- a/optimum_benchmark/backends/pytorch/backend.py
+++ b/optimum_benchmark/backends/pytorch/backend.py
@@ -28,7 +28,7 @@ class PyTorchBackend(Backend[PyTorchConfig]):
         super().__init__(model, task, device, hub_kwargs)
 
         automodel = self.automodel_class.__name__
-        LOGGER.info(f"\t+ Infered AutoModel class {automodel} for task {self.task} and model_type {self.model_type}")
+        LOGGER.info(f"\t+ Inferred AutoModel class {automodel} for task {self.task} and model_type {self.model_type}")
 
     def configure(self, config: PyTorchConfig) -> None:
         super().configure(config)

--- a/optimum_benchmark/backends/text_generation_inference/backend.py
+++ b/optimum_benchmark/backends/text_generation_inference/backend.py
@@ -31,7 +31,7 @@ class TGIBackend(Backend[TGIConfig]):
         self.validate_task()
 
         automodel = self.automodel_class.__name__
-        LOGGER.info(f"\t+ Infered AutoModel class {automodel} for task {self.task} and model_type {self.model_type}")
+        LOGGER.info(f"\t+ Inferred AutoModel class {automodel} for task {self.task} and model_type {self.model_type}")
 
     def validate_task(self) -> None:
         if self.task not in ["text-generation", "text2text-generation"]:
@@ -144,7 +144,7 @@ class TGIBackend(Backend[TGIConfig]):
             self.pretrained_model = self.automodel_class.from_pretrained(self.model, **self.hub_kwargs)
 
     def modify_generation_config(self) -> None:
-        # this should, theorically, make the generated output's sequence length fully controlled by max_new_tokens
+        # this should, theoretically, make the generated output's sequence length fully controlled by max_new_tokens
         # instead of stopping at the first eos_token_id/pad_token_id
         generation_config = GenerationConfig.from_pretrained(self.model, **self.hub_kwargs)
         generation_config.eos_token_id = -100
@@ -199,7 +199,7 @@ class TGIBackend(Backend[TGIConfig]):
         super().clean()
 
         if hasattr(self, "tgi_container"):
-            LOGGER.info("\t+ Stoping TGI container")
+            LOGGER.info("\t+ Stopping TGI container")
             self.tgi_container.stop()
             LOGGER.info("\t+ Waiting for TGI container to stop")
             self.tgi_container.wait()

--- a/optimum_benchmark/report.py
+++ b/optimum_benchmark/report.py
@@ -79,7 +79,10 @@ def format_row(row, style=""):
 
 
 def get_inference_rich_table(inference_report, with_baseline=False, with_generate=False, title=""):
-    perf_columns = ["forward.latency(s)", "forward.throughput(samples/s)",] + (
+    perf_columns = [
+        "forward.latency(s)",
+        "forward.throughput(samples/s)",
+    ] + (
         [
             "forward.peak_memory(MB)",
         ]

--- a/optimum_benchmark/report.py
+++ b/optimum_benchmark/report.py
@@ -143,7 +143,7 @@ def get_inference_rich_table(inference_report, with_baseline=False, with_generat
 
 
 def get_inference_plots(report, with_baseline=False, with_generate=False, subtitle=""):
-    # create bar charts seperately
+    # create bar charts separately
     fig1, ax1 = plt.subplots(figsize=(20, 10))
     fig2, ax2 = plt.subplots(figsize=(20, 10))
 

--- a/optimum_benchmark/report.py
+++ b/optimum_benchmark/report.py
@@ -79,10 +79,7 @@ def format_row(row, style=""):
 
 
 def get_inference_rich_table(inference_report, with_baseline=False, with_generate=False, title=""):
-    perf_columns = [
-        "forward.latency(s)",
-        "forward.throughput(samples/s)",
-    ] + (
+    perf_columns = ["forward.latency(s)", "forward.throughput(samples/s)",] + (
         [
             "forward.peak_memory(MB)",
         ]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix various typos.

## Details
I found the first few manually in the README, and then found the rest via `codespell`.

## Note
There's another typo which seems more critical to the behaviour of the package, so I did not change that one:
https://github.com/huggingface/optimum-benchmark/blob/90ad2ea78d23ad59ef23ee9552a1c484706ec336/optimum_benchmark/benchmarks/training/benchmark.py#L53

`samles` should be `samples`. Because of this, a bunch of the csv's also have this `samles`: https://github.com/huggingface/optimum-benchmark/blob/90ad2ea78d23ad59ef23ee9552a1c484706ec336/examples/training-llamas/experiments/A100-80GB/llama_peft%2Bbnb_batch_size(2)/1/training_results.csv

I'll leave this one for you to fix, as I'm not sure how it all connects together.

- Tom Aarsen