### PR TITLE
Update cuda (12) and torch (2.1)

### DIFF
--- a/.github/workflows/test_cuda_onnxruntime_inference.yaml
+++ b/.github/workflows/test_cuda_onnxruntime_inference.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          opt-bench-cuda
+          opt-bench-cuda:11.8.0-cudnn8
           -c "pip install -e .[test,onnxruntime-gpu,diffusers] && pytest -k 'cuda and onnxruntime and inference' -x"

--- a/.github/workflows/test_cuda_onnxruntime_inference.yaml
+++ b/.github/workflows/test_cuda_onnxruntime_inference.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          optimum-benchmark-gpu
-          -c "pip install -e .[test,onnxruntime-gpu,diffusers] && pytest -k '(cuda or tensorrt) and onnxruntime and not training' -x"
+          opt-bench-cuda
+          -c "pip install -e .[test,onnxruntime-gpu,diffusers] && pytest -k 'cuda and onnxruntime and inference' -x"

--- a/.github/workflows/test_cuda_onnxruntime_training.yaml
+++ b/.github/workflows/test_cuda_onnxruntime_training.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          onnxruntime-training
+          onnxruntime-training:11.8.0-cudnn8
           -c "pip install -e .[test,peft] && pytest -k 'cuda and onnxruntime and training' -x"

--- a/.github/workflows/test_cuda_pytorch.yaml
+++ b/.github/workflows/test_cuda_pytorch.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          optimum-benchmark-gpu
-          -c "pip install -e .[test,peft,diffusers] && pytest -k 'cuda_pytorch' -x"
+          opt-bench-cuda
+          -c "pip install -e .[test,peft,diffusers] && pytest -k 'cuda and pytorch' -x"

--- a/.github/workflows/test_cuda_pytorch.yaml
+++ b/.github/workflows/test_cuda_pytorch.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          opt-bench-cuda
+          opt-bench-cuda:12.1.1-cudnn8
           -c "pip install -e .[test,peft,diffusers] && pytest -k 'cuda and pytorch' -x"

--- a/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
+++ b/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          opt-bench-tensorrt:23.09
+          opt-bench-tensorrt:22.12
           -c "pip install -e .[test,onnxruntime-gpu,diffusers] && pytest -k 'tensorrt and onnxruntime and inference' -x"

--- a/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
+++ b/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
@@ -1,4 +1,4 @@
-name: OnnxRuntime CUDA Training Tests
+name: OnnxRuntime CUDA Inference Tests
 
 on:
   pull_request:
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          onnxruntime-training
-          -c "pip install -e .[test,peft] && pytest -k 'cuda and onnxruntime and training' -x"
+          opt-bench-tensorrt
+          -c "pip install -e .[test,onnxruntime-gpu,diffusers] && pytest -k 'tensorrt and onnxruntime and inference' -x"

--- a/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
+++ b/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
@@ -33,5 +33,5 @@ jobs:
           --gpus '"device=0,1"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
-          opt-bench-tensorrt
+          opt-bench-tensorrt:23.09
           -c "pip install -e .[test,onnxruntime-gpu,diffusers] && pytest -k 'tensorrt and onnxruntime and inference' -x"

--- a/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
+++ b/.github/workflows/test_tensorrt_onnxruntime_inference.yaml
@@ -1,4 +1,4 @@
-name: OnnxRuntime CUDA Inference Tests
+name: OnnxRuntime TensorRT Inference Tests
 
 on:
   pull_request:

--- a/docker/cuda.dockerfile
+++ b/docker/cuda.dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2023 The HuggingFace Team All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# docker build -f docker/cuda.dockerfile -t opt-bench-cuda:12.1.1-cudnn8 .
+FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+
+# Ignore interactive questions during `docker build`
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install and update tools to minimize security vulnerabilities
+RUN apt-get update
+RUN apt-get install -y software-properties-common wget apt-utils patchelf git libprotobuf-dev protobuf-compiler cmake \
+    bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 mercurial subversion libopenmpi-dev && \
+    apt-get clean
+RUN unattended-upgrade
+RUN apt-get autoremove -y

--- a/docker/cuda.dockerfile
+++ b/docker/cuda.dockerfile
@@ -25,3 +25,7 @@ RUN apt-get install -y software-properties-common wget apt-utils patchelf git li
     apt-get clean
 RUN unattended-upgrade
 RUN apt-get autoremove -y
+
+# Install python
+RUN apt-get install -y python3 python3-pip python3-dev python3-setuptools python3-wheel python3-venv && \
+    apt-get clean

--- a/docker/cuda.dockerfile
+++ b/docker/cuda.dockerfile
@@ -37,3 +37,5 @@ RUN apt-get autoremove -y
 # Install python
 RUN apt-get install -y python3 python3-pip python3-dev python3-setuptools python3-wheel python3-venv && \
     apt-get clean
+
+RUN pip install --upgrade pip

--- a/docker/cuda.dockerfile
+++ b/docker/cuda.dockerfile
@@ -12,8 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# to build with 12.1.1-cudnn8-devel-ubuntu22.04
 # docker build -f docker/cuda.dockerfile -t opt-bench-cuda:12.1.1-cudnn8 .
-FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+# to build with 11.8.0-cudnn8-devel-ubuntu22.04
+# docker build -f docker/cuda.dockerfile -t opt-bench-cuda:11.8.0-cudnn8 --build-arg CUDA_VERSION=11.8.0 --build-arg UBUNTU_VERSION=22.04 .
+
+ARG CUDA_VERSION=12.1.1
+ARG CUDNN_VERSION=8
+ARG UBUNTU_VERSION=22.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 # Ignore interactive questions during `docker build`
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/cuda.dockerfile
+++ b/docker/cuda.dockerfile
@@ -17,8 +17,8 @@
 # to build with 11.8.0-cudnn8-devel-ubuntu22.04
 # docker build -f docker/cuda.dockerfile -t opt-bench-cuda:11.8.0-cudnn8 --build-arg CUDA_VERSION=11.8.0 --build-arg UBUNTU_VERSION=22.04 .
 
-ARG CUDA_VERSION=12.1.1
 ARG CUDNN_VERSION=8
+ARG CUDA_VERSION=12.1.1
 ARG UBUNTU_VERSION=22.04
 
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel-ubuntu${UBUNTU_VERSION}

--- a/docker/onnxruntime_training.dockerfile
+++ b/docker/onnxruntime_training.dockerfile
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use nvidia/cuda image
 # docker build -f docker/onnxruntime_training.dockerfile -t onnxruntime-training .
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 
 # Ignore interactive questions during `docker build`
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/onnxruntime_training.dockerfile
+++ b/docker/onnxruntime_training.dockerfile
@@ -39,6 +39,8 @@ RUN apt-get autoremove -y
 RUN apt-get install -y python3 python3-pip python3-dev python3-setuptools python3-wheel python3-venv && \
     apt-get clean
 
+RUN pip install --upgrade pip
+
 # Install dependencies
 RUN pip install onnx ninja
 RUN pip install onnxruntime-training==1.15.1

--- a/docker/onnxruntime_training.dockerfile
+++ b/docker/onnxruntime_training.dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Use nvidia/cuda image
+# docker build -f docker/onnxruntime_training.dockerfile -t onnxruntime-training .
 FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
 
 # Ignore interactive questions during `docker build`

--- a/docker/tensorrt.dockerfile
+++ b/docker/tensorrt.dockerfile
@@ -32,3 +32,5 @@ RUN apt-get install -y software-properties-common wget apt-utils patchelf git li
     apt-get clean
 RUN unattended-upgrade
 RUN apt-get autoremove -y
+
+RUN pip install --upgrade pip

--- a/docker/tensorrt.dockerfile
+++ b/docker/tensorrt.dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# use version with CUDA 11.8 and TensorRT 8.5.1.7 to match ORT 1.14 requirements
+# https://docs.nvidia.com/deeplearning/tensorrt/container-release-notes/index.html#rel-23-09
+# docker build -f docker/cuda.dockerfile -t opt-bench-tensorrt:23.09 .
 FROM nvcr.io/nvidia/tensorrt:23.09-py3
 
 # Ignore interactive questions during `docker build`

--- a/docker/tensorrt.dockerfile
+++ b/docker/tensorrt.dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # https://docs.nvidia.com/deeplearning/tensorrt/container-release-notes/index.html#rel-23-09
-# docker build -f docker/cuda.dockerfile -t opt-bench-tensorrt:23.09 .
+# docker build -f docker/tensorrt.dockerfile -t opt-bench-tensorrt:23.09 .
 FROM nvcr.io/nvidia/tensorrt:23.09-py3
 
 # Ignore interactive questions during `docker build`

--- a/docker/tensorrt.dockerfile
+++ b/docker/tensorrt.dockerfile
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://docs.nvidia.com/deeplearning/tensorrt/container-release-notes/index.html#rel-23-09
+
+# to build with tensorrt:23.09
 # docker build -f docker/tensorrt.dockerfile -t opt-bench-tensorrt:23.09 .
-FROM nvcr.io/nvidia/tensorrt:23.09-py3
+
+ARG TENSORRT_VERSION=23.09
+
+FROM nvcr.io/nvidia/tensorrt:${TENSORRT_VERSION}-py3
 
 # Ignore interactive questions during `docker build`
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/tensorrt.dockerfile
+++ b/docker/tensorrt.dockerfile
@@ -15,6 +15,8 @@
 
 # to build with tensorrt:23.09
 # docker build -f docker/tensorrt.dockerfile -t opt-bench-tensorrt:23.09 .
+# to build with tensorrt:22.12
+# docker build -f docker/tensorrt.dockerfile --build-arg TENSORRT_VERSION=22.12 -t opt-bench-tensorrt:22.12 .
 
 ARG TENSORRT_VERSION=23.09
 

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ EXTRAS_REQUIRE = {
     "report": ["flatten_dict", "matplotlib", "seaborn", "rich"],
     # cpu backends
     "openvino": [f"optimum[openvino,nncf]>={OPTIMUM_VERSION}"],
-    "onnxruntime": [f"optimum[onnxruntime]>={OPTIMUM_VERSION}"],
-    "onnxruntime-gpu": [f"optimum[onnxruntime-gpu]>={OPTIMUM_VERSION}", "torch==2.0"],
+    "onnxruntime": [f"optimum[onnxruntime]>={OPTIMUM_VERSION}", "torch==2.0.1"],
+    "onnxruntime-gpu": [f"optimum[onnxruntime-gpu]>={OPTIMUM_VERSION}", "torch==2.0.1"],
     "neural-compressor": [f"optimum[neural-compressor]>={OPTIMUM_VERSION}"],
     # server-like backend
     "text-generation-inference": ["docker==6.1.3"],

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ EXTRAS_REQUIRE = {
     # cpu backends
     "openvino": [f"optimum[openvino,nncf]>={OPTIMUM_VERSION}"],
     "onnxruntime": [f"optimum[onnxruntime]>={OPTIMUM_VERSION}"],
-    "onnxruntime-gpu": [f"optimum[onnxruntime-gpu]>={OPTIMUM_VERSION}"],
+    "onnxruntime-gpu": [f"optimum[onnxruntime-gpu]>={OPTIMUM_VERSION}", "torch==2.0"],
     "neural-compressor": [f"optimum[neural-compressor]>={OPTIMUM_VERSION}"],
     # server-like backend
     "text-generation-inference": ["docker==6.1.3"],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ INSTALL_REQUIRES = [
     "codecarbon==2.3.1",
     "psutil==5.9.0",
     "pandas>=2.0.0",
-    "torch==2.0.1",
 ]
 
 # add py3nvml if nvidia driver is installed


### PR DESCRIPTION
This PR updates the versions of `cuda` and `torch` used in workflows:
- `cuda`: 11.8 -> 12.1
- `torch`: 2.0 -> 2.1 (unpinned)

except for `onnxruntime` which is built with 11.x https://github.com/microsoft/onnxruntime/issues/17864#issuecomment-1756366508