### PR TITLE
Modular and generic cli reporting utilities

### DIFF
--- a/optimum_benchmark/aggregators/display.py
+++ b/optimum_benchmark/aggregators/display.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Optional
 
 import pandas as pd
 from rich.console import Console

--- a/optimum_benchmark/aggregators/display.py
+++ b/optimum_benchmark/aggregators/display.py
@@ -1,0 +1,86 @@
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from rich.console import Console
+from rich.table import Table
+from rich.terminal_theme import MONOKAI
+
+
+def style_element(element, style=""):
+    if style:
+        return f"[{style}]{element}[/{style}]"
+    else:
+        return element
+
+
+def format_element(element, style=""):
+    if isinstance(element, float):
+        if element != element:
+            formated_element = ""
+        elif abs(element) >= 1:
+            formated_element = f"{element:.2f}"
+        elif abs(element) > 1e-6:
+            formated_element = f"{element:.2e}"
+        else:
+            formated_element = f"{element}"
+    elif element is None:
+        formated_element = ""
+    elif isinstance(element, bool):
+        if element:
+            formated_element = style_element("✔", style="green")
+        else:
+            formated_element = style_element("✘", style="red")
+    else:
+        formated_element = str(element)
+
+    return style_element(formated_element, style=style)
+
+
+def format_row(row, style=""):
+    formated_row = []
+    for element in row:
+        formated_row.append(format_element(element, style=style))
+    return formated_row
+
+
+def display(report: pd.DataFrame) -> Table:
+    table = Table(show_header=True, show_lines=True)
+
+    for column in report.columns:
+        table.add_column(column, justify="right", header_style="bold")
+
+    for _, row in report.iterrows():
+        table.add_row(*format_row(row.values, style=""))
+
+    console = Console(record=True)
+    console.print(table, justify="center")
+
+    return console, table
+
+
+def display_cli() -> None:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--report",
+        "-r",
+        type=Path,
+        default=Path("artifacts/short_report.csv"),
+        help="The short report to format.",
+    )
+    parser.add_argument(
+        "--save-file",
+        "-s",
+        type=Path,
+        default=Path("artifacts/rich_table.svg"),
+        help="Path to the svg file",
+    )
+
+    args = parser.parse_args()
+    report = pd.read_csv(args.report)
+    console, _ = display(report=report)
+
+    if args.save_file is not None:
+        args.save_file.parent.mkdir(parents=True, exist_ok=True)
+        console.save_svg(args.save_file, theme=MONOKAI, title="Rich Report")

--- a/optimum_benchmark/aggregators/gather.py
+++ b/optimum_benchmark/aggregators/gather.py
@@ -1,0 +1,68 @@
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+from flatten_dict import flatten
+from omegaconf import OmegaConf
+
+
+def gather(root_folders: List[Path]) -> pd.DataFrame:
+    results_dfs = {}
+    configs_dfs = {}
+
+    for root_folder in root_folders:
+        if not root_folder.exists():
+            raise ValueError(f"{root_folder} does not exist")
+
+        for f in root_folder.glob("**/*_results.csv"):
+            parent_folder = f.parent.absolute().as_posix()
+            results_df = pd.read_csv(f)
+            results_dfs[parent_folder] = results_df
+
+        for f in root_folder.glob("**/hydra_config.yaml"):
+            parent_folder = f.parent.absolute().as_posix()
+            config_df = pd.DataFrame.from_dict(flatten(OmegaConf.load(f), reducer="dot"), orient="index").T
+            configs_dfs[parent_folder] = config_df
+
+    if (len(results_dfs) == 0) or (len(configs_dfs) == 0):
+        raise ValueError(f"No results found in {root_folder}")
+    elif len(results_dfs) != len(configs_dfs):
+        raise ValueError(f"Results and configs do not match in {root_folder}")
+
+    # Merge inference and config dataframes
+    full_dfs = {}
+    for parent_folder in results_dfs:
+        full_df = pd.merge(results_dfs[parent_folder], configs_dfs[parent_folder], left_index=True, right_index=True)
+        full_dfs[parent_folder] = full_df
+
+    # Concatenate all dataframes
+    full_report = pd.concat(full_dfs.values(), ignore_index=True, axis=0)
+
+    return full_report
+
+
+def gather_cli() -> None:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--root-folders",
+        "-r",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="The folders containing the experiments to report on.",
+    )
+    parser.add_argument(
+        "--save-file",
+        "-s",
+        type=Path,
+        default=Path("artifacts/full_report.csv"),
+        help="Path to the report file",
+    )
+
+    args = parser.parse_args()
+    report = gather(root_folders=args.root_folders)
+
+    if args.save_file is not None:
+        args.save_file.parent.mkdir(parents=True, exist_ok=True)
+        report.to_csv(args.save_file, index=False)

--- a/optimum_benchmark/aggregators/plot.py
+++ b/optimum_benchmark/aggregators/plot.py
@@ -1,0 +1,69 @@
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot(
+    report: pd.DataFrame,
+    x_axis: str = "Batch Size",
+    y_axis: str = "Forward Latency (s)",
+    groupby: str = "Experiment",
+) -> Tuple[plt.Figure, plt.Axes]:
+    fig, ax = plt.subplots()
+
+    for group, sweep in report.groupby(groupby):
+        ax.plot(sweep[x_axis], sweep[y_axis], label=group, marker="o")
+
+    ax.set_xlabel(x_axis)
+    ax.set_ylabel(y_axis)
+    ax.set_title(f"{y_axis} per {x_axis}")
+    ax.legend(fancybox=True, shadow=True)
+
+    return fig, ax
+
+
+def plot_cli() -> None:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--report",
+        "-r",
+        type=Path,
+        default=Path("artifacts/full_report.csv"),
+        help="Path to the report csv file",
+    )
+    parser.add_argument(
+        "--x-axis",
+        "-x",
+        default="Batch Size",
+        help="X axis column",
+    )
+    parser.add_argument(
+        "--y-axis",
+        "-y",
+        default="Forward Latency (s)",
+        help="Y axis column",
+    )
+    parser.add_argument(
+        "--groupby",
+        "-g",
+        default="Experiment",
+        help="Groupby column",
+    )
+    parser.add_argument(
+        "--save-file",
+        "-s",
+        type=Path,
+        default=Path("artifacts/plot.png"),
+        help="Path to the plot file",
+    )
+
+    args = parser.parse_args()
+    report = pd.read_csv(args.report)
+    fig, _ = plot(report=report, x_axis=args.x_axis, y_axis=args.y_axis, groupby=args.groupby)
+
+    if args.save_file is not None:
+        args.save_file.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(args.save_file)

--- a/optimum_benchmark/aggregators/plot.py
+++ b/optimum_benchmark/aggregators/plot.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Tuple
 
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/optimum_benchmark/aggregators/summarize.py
+++ b/optimum_benchmark/aggregators/summarize.py
@@ -1,7 +1,7 @@
+import json
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Dict, Optional
-import json
+from typing import Dict
 
 import pandas as pd
 

--- a/optimum_benchmark/aggregators/summarize.py
+++ b/optimum_benchmark/aggregators/summarize.py
@@ -1,0 +1,60 @@
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Dict, Optional
+import json
+
+import pandas as pd
+
+
+def summarize(
+    report: pd.DataFrame,
+    rename_dict: Dict[str, str],
+):
+    summarized_report = report[list(rename_dict.keys())].rename(columns=rename_dict)
+
+    return summarized_report
+
+
+def summarize_cli() -> None:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--report",
+        "-r",
+        type=Path,
+        default=Path("artifacts/full_report.csv"),
+        help="Path to the full report csv file",
+    )
+    parser.add_argument(
+        "--rename-json",
+        "-j",
+        type=Path,
+        help="Path to the rename json file",
+    )
+    parser.add_argument(
+        "--save-file",
+        "-s",
+        type=Path,
+        default=Path("artifacts/summarized_report.csv"),
+        help="Path to the report file",
+    )
+
+    args = parser.parse_args()
+
+    if args.rename_json is None:
+        rename_dict = {
+            "experiment_name": "Experiment",
+            "benchmark.name": "Benchmark",
+            "backend.name": "Backend",
+        }
+    else:
+        rename_dict = json.load(args.rename_json.open("r"))
+
+    report = pd.read_csv(args.report)
+    summarized_report = summarize(
+        report=report,
+        rename_dict=rename_dict,
+    )
+
+    if args.save_file is not None:
+        args.save_file.parent.mkdir(parents=True, exist_ok=True)
+        summarized_report.to_csv(args.save_file, index=False)

--- a/optimum_benchmark/report.py
+++ b/optimum_benchmark/report.py
@@ -1,9 +1,9 @@
 import sys
 
-from .aggregators.gather import gather_cli
 from .aggregators.display import display_cli
-from .aggregators.summarize import summarize_cli
+from .aggregators.gather import gather_cli
 from .aggregators.plot import plot_cli
+from .aggregators.summarize import summarize_cli
 
 HELP = """
 Usage: optimum-report <action> <options>

--- a/optimum_benchmark/report.py
+++ b/optimum_benchmark/report.py
@@ -1,293 +1,37 @@
-from argparse import ArgumentParser
-from pathlib import Path
+import sys
 
-import matplotlib.pyplot as plt
-import pandas as pd
-import seaborn as sns
-from flatten_dict import flatten
-from omegaconf import OmegaConf
-from pandas import DataFrame
-from rich.console import Console
-from rich.table import Table
-from rich.terminal_theme import MONOKAI
+from .aggregators.gather import gather_cli
+from .aggregators.display import display_cli
+from .aggregators.summarize import summarize_cli
+from .aggregators.plot import plot_cli
 
+HELP = """
+Usage: optimum-report <action> <options>
+Actions:
+    gather
+    display
+    summarize
+    plot
+    -h, --help
 
-def gather_inference_report(root_folder: Path) -> DataFrame:
-    # key is path to inference file as string, value is dataframe
-    inference_dfs = {
-        f.parent.absolute().as_posix(): pd.read_csv(f) for f in root_folder.glob("**/inference_results.csv")
-    }
-
-    # key is path to config file as string, value is flattened dict
-    config_dfs = {
-        f.parent.absolute()
-        .as_posix(): pd.DataFrame.from_dict(flatten(OmegaConf.load(f), reducer="dot"), orient="index")
-        .T
-        for f in root_folder.glob("**/hydra_config.yaml")
-        if f.parent.absolute().as_posix() in inference_dfs.keys()
-    }
-
-    if len(inference_dfs) == 0 or len(config_dfs) == 0:
-        raise ValueError(f"No results found in {root_folder}")
-
-    # Merge inference and config dataframes
-    inference_reports = [
-        config_dfs[name].merge(inference_dfs[name], left_index=True, right_index=True) for name in inference_dfs.keys()
-    ]
-
-    # Concatenate all reports
-    inference_report = pd.concat(inference_reports, axis=0, ignore_index=True)
-    inference_report.set_index("experiment_name", inplace=True)
-    return inference_report
+For more information on each action, run:
+    optimum-report <action> -h
+"""
 
 
-def style_element(element, style=""):
-    if style:
-        return f"[{style}]{element}[/{style}]"
+def main():
+    action = sys.argv[1]
+    sys.argv = sys.argv[1:]
+
+    if action == "gather":
+        gather_cli()
+    elif action == "display":
+        display_cli()
+    elif action == "summarize":
+        summarize_cli()
+    elif action == "plot":
+        plot_cli()
+    elif action in ["-h", "--help"]:
+        print(HELP)
     else:
-        return element
-
-
-def format_element(element, style=""):
-    if isinstance(element, float):
-        if element != element:  # nan
-            formated_element = ""
-        elif abs(element) >= 1:
-            formated_element = f"{element:.2f}"
-        elif abs(element) > 1e-6:
-            formated_element = f"{element:.2e}"
-        else:
-            formated_element = f"{element}"
-    elif element is None:
-        formated_element = ""
-    elif isinstance(element, bool):
-        if element:
-            formated_element = style_element("✔", style="green")
-        else:
-            formated_element = style_element("✘", style="red")
-    else:
-        formated_element = str(element)
-
-    return style_element(formated_element, style=style)
-
-
-def format_row(row, style=""):
-    formated_row = []
-    for element in row:
-        formated_row.append(format_element(element, style=style))
-    return formated_row
-
-
-def get_inference_rich_table(inference_report, with_baseline=False, with_generate=False, title=""):
-    perf_columns = [
-        "forward.latency(s)",
-        "forward.throughput(samples/s)",
-    ] + (
-        [
-            "forward.peak_memory(MB)",
-        ]
-        if "forward.peak_memory(MB)" in inference_report.columns
-        else []
-    )
-
-    if with_baseline:
-        perf_columns.append("forward.speedup(%)")
-
-    if with_generate:
-        perf_columns += ["generate.latency(s)", "generate.throughput(tokens/s)"]
-        if with_baseline:
-            perf_columns.append("generate.speedup(%)")
-
-    additional_columns = [
-        col
-        for col in inference_report.columns
-        if inference_report[col].nunique() > 1 and "backend" in col and "_target_" not in col and "version" not in col
-    ]
-
-    # display interesting columns in multilevel hierarchy
-    display_report = inference_report[additional_columns + perf_columns]
-    display_report.columns = pd.MultiIndex.from_tuples([tuple(col.split(".")) for col in display_report.columns])
-
-    # create rich table
-    rich_table = Table(show_header=True, title=title, show_lines=True)
-    # we add a column for the index
-    rich_table.add_column("Experiment Name", justify="left", header_style="")
-    # then we add the rest of the columns
-    for level in range(display_report.columns.nlevels):
-        columns = display_report.columns.get_level_values(level).to_list()
-        for i in range(len(columns)):
-            if columns[i] != columns[i]:  # nan
-                columns[i] = ""
-
-        if level < display_report.columns.nlevels - 1:
-            for col in columns:
-                rich_table.add_column(col, header_style="")
-            pass
-        else:
-            rich_table.add_row(
-                "",
-                *columns,
-                end_section=True,
-            )
-
-    # we populate the table with values
-    for i, row in enumerate(display_report.itertuples(index=True)):
-        if with_baseline and i == display_report.shape[0] - 1:
-            table_row = format_row(row, style="yellow")
-        else:
-            table_row = format_row(row)
-
-        rich_table.add_row(*table_row)
-
-    return rich_table
-
-
-def get_inference_plots(report, with_baseline=False, with_generate=False, subtitle=""):
-    # create bar charts separately
-    fig1, ax1 = plt.subplots(figsize=(20, 10))
-    fig2, ax2 = plt.subplots(figsize=(20, 10))
-
-    sns.barplot(
-        x=report.index,
-        y=report["forward.throughput(samples/s)"],
-        ax=ax1,
-        width=0.5,
-    )
-    ax1.set_xticklabels(ax1.get_xticklabels(), rotation=45, horizontalalignment="right")
-    ax1.set_xlabel("Experiment")
-    ax1.set_ylabel("Forward Throughput (samples/s)")
-    ax1.set_title("Forward Throughput by Experiment" + "\n" + subtitle)
-
-    if with_generate:
-        fig2, ax2 = plt.subplots(figsize=(20, 10))
-        sns.barplot(
-            x=report.index,
-            y=report["generate.throughput(tokens/s)"],
-            ax=ax2,
-            width=0.5,
-        )
-        ax2.set_xticklabels(ax2.get_xticklabels(), rotation=45, horizontalalignment="right")
-        ax2.set_xlabel("Experiment")
-        ax2.set_ylabel("Generate Throughput (tokens/s)")
-        ax2.set_title("Generate Throughput by Experiment" + "\n" + subtitle)
-
-    if with_baseline:
-        # add speedup text on top of each bar
-        baselineforward_throughput = report["forward.throughput(samples/s)"].iloc[-1]
-        for p in ax1.patches:
-            speedup = (p.get_height() / baselineforward_throughput - 1) * 100
-            ax1.annotate(
-                f"{'+' if speedup>0 else '-'}{abs(speedup):.2f}%",
-                (p.get_x() + p.get_width() / 2, 1.02 * p.get_height()),
-                ha="center",
-                va="center",
-            )
-        ax1.set_title("Forward Throughput and Speedup by Experiment" + "\n" + subtitle)
-
-        if with_generate:
-            # add speedup text on top of each bar
-            baseline_generate_throughput = report["generate.throughput(tokens/s)"].iloc[-1]
-            for p in ax2.patches:
-                speedup = (p.get_height() / baseline_generate_throughput - 1) * 100
-                ax2.annotate(
-                    f"{'+' if speedup>0 else '-'}{abs(speedup):.2f}%",
-                    (p.get_x() + p.get_width() / 2, 1.02 * p.get_height()),
-                    ha="center",
-                    va="center",
-                )
-            ax2.set_title("Generate Throughput and Speedup by Experiment" + "\n" + subtitle)
-
-    return fig1, fig2
-
-
-def compute_speedup(report, with_generate=False):
-    # compute speedup for each experiment compared to baseline
-    report["forward.speedup(%)"] = (
-        report["forward.throughput(samples/s)"] / report["forward.throughput(samples/s)"].iloc[-1] - 1
-    ) * 100
-
-    if with_generate:
-        report["generate.speedup(%)"] = (
-            report["generate.throughput(tokens/s)"] / report["generate.throughput(tokens/s)"].iloc[-1] - 1
-        ) * 100
-
-    return report
-
-
-def generate_report():
-    parser = ArgumentParser()
-    parser.add_argument(
-        "--experiments",
-        "-e",
-        nargs="*",
-        type=Path,
-        required=True,
-        help="The folder containing the results of experiments.",
-    )
-    parser.add_argument(
-        "--baseline",
-        "-b",
-        type=Path,
-        required=False,
-        help="The folders containing the results of baseline.",
-    )
-    parser.add_argument(
-        "--report-name",
-        "-n",
-        type=str,
-        required=False,
-        help="The name of the report.",
-    )
-
-    args = parser.parse_args()
-
-    experiments_folders = args.experiments
-    baseline_folder = args.baseline
-    report_name = args.report_name
-
-    # gather experiments reports
-    inference_experiments = [gather_inference_report(experiment) for experiment in experiments_folders]
-    inference_report = pd.concat(inference_experiments, axis=0)
-
-    # sort by forward throughput
-    inference_report.sort_values(by="forward.throughput(samples/s)", ascending=False, inplace=True)
-
-    # some flags
-    with_baseline = baseline_folder is not None
-    with_generate = "generate.throughput(tokens/s)" in inference_report.columns
-
-    if with_baseline:
-        # gather baseline report
-        inference_baseline = gather_inference_report(baseline_folder)
-        assert inference_baseline.shape[0] == 1, "baseline folder should contain only one experiment"
-        # add baseline to experiment
-        inference_report = pd.concat([inference_report, inference_baseline], axis=0)
-        # compute speedup compared to baseline
-        inference_report = compute_speedup(inference_report, with_generate)
-
-    # create reporting directory and title using the filters
-    if report_name is None:
-        report_name = "Inference Report"
-        reporting_directory = "reports/inference_report"
-    else:
-        reporting_directory = f"reports/{report_name}"
-
-    Path(reporting_directory).mkdir(exist_ok=True, parents=True)
-
-    # rich table
-    rich_table = get_inference_rich_table(inference_report, with_baseline, with_generate, report_name)
-    console = Console(record=True)
-    console.print(rich_table, justify="left", no_wrap=True)
-    console.save_svg(f"{reporting_directory}/rich_table.svg", theme=MONOKAI)
-
-    # plots
-    forward_fig, generate_fig = get_inference_plots(inference_report, with_baseline, with_generate, report_name)
-    forward_fig.tight_layout()
-    forward_fig.savefig(f"{reporting_directory}/forward_throughput.png")
-
-    if generate_fig is not None:
-        generate_fig.tight_layout()
-        generate_fig.savefig(f"{reporting_directory}/generate_throughput.png")
-
-    # csv
-    inference_report.to_csv(f"{reporting_directory}/inference_report.csv", index=True)
+        raise ValueError(f"Unknown action {action}")

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if use_rocm == "1":
 EXTRAS_REQUIRE = {
     "test": ["pytest"],
     "quality": ["black", "ruff"],
-    "report": ["flatten_dict", "matplotlib", "seaborn", "rich"],
+    "report": ["matplotlib", "rich", "tabulate", "flatten_dict"],
     # cpu backends
     "openvino": [f"optimum[openvino,nncf]>={OPTIMUM_VERSION}"],
     "onnxruntime": [f"optimum[onnxruntime]>={OPTIMUM_VERSION}"],
@@ -70,7 +70,7 @@ setup(
     entry_points={
         "console_scripts": [
             "optimum-benchmark=optimum_benchmark.experiment:main",
-            "optimum-report=optimum_benchmark.report:generate_report",
+            "optimum-report=optimum_benchmark.report:main",
         ]
     },
 )


### PR DESCRIPTION
Since I've been re using the same code in the examples for a while, I think it's time to make it part of `optimum-benchmark`.
There are four cli commands for reporting that can be used independently or sequentially.

### `optimum-report gather`
To gather all the results in one single file, run:

```bash
optimum-report gather --root-folders experiments/A100-80GB/ --save-file artifacts/A100-80GB/full_report.csv
```

### `optimum-report summarize`
To summarize the results from the csv (only keep some columns), run:

```bash
optimum-report summarize --rreport artifacts/A100-80GB/full_report.csv --rename-json artifacts/rename.json --save-file artifacts/A100-80GB/summarized_report.csv
```

### `optimum-report display`
To display the summarized results in the terminal as a `rich` table, run:

```bash
optimum-report display --report artifacts/A100-80GB/summarized_report.csv --save-file artifacts/A100-80GB/rich_table.svg
```

### `optimum-report plot`
To plot the results, run:

```bash
optimum-report plot --report artifacts/A100-80GB/summarized_report.csv --x-axis "Batch Size" --y-axis "Forward Latency (s)" --groupby "Experiment" --save-file artifacts/A100-80GB/forward_latency_plot.png
```