### PR TITLE
Add rocm5.7 support

### DIFF
--- a/.github/workflows/test_rocm_pytorch.yaml
+++ b/.github/workflows/test_rocm_pytorch.yaml
@@ -11,20 +11,43 @@ concurrency:
 
 jobs:
   build_image_and_run_gpu_tests:
-    runs-on: hf-amd-mi210-dev
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          [
+            {
+              rocm_version: 5.6.1,
+              torch_rocm_version: 5.6,
+              torch_pre_release: 0,
+            },
+            {
+              rocm_version: 5.7,
+              torch_rocm_version: 5.7,
+              torch_pre_release: 1,
+            },
+          ]
+        runner: [hf-amd-mi210-dev]
+
+    runs-on: ${{ matrix.runner }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Build image
         run: docker build
           --file docker/rocm.dockerfile
           --build-arg USER_ID=$(id -u)
           --build-arg GROUP_ID=$(id -g)
-          --build-arg ROCM_VERSION=5.6.1
-          --build-arg TORCH_ROCM=rocm5.6
-          --tag opt-bench-rocm:5.6.1
+          --build-arg ROCM_VERSION=$ROCM_VERSION
+          --build-arg TORCH_PRE_RELEASE=$TORCH_PRE_RELEASE
+          --build-arg TORCH_ROCM_VERSION=$TORCH_ROCM_VERSION
+          --tag opt-bench-rocm:$TORCH_ROCM_VERSION
           .
+        env:
+          ROCM_VERSION: ${{ matrix.image.rocm_version }}
+          TORCH_ROCM_VERSION: ${{ matrix.image.torch_rocm_version }}
+          TORCH_PRE_RELEASE: ${{ matrix.image.torch_pre_release }}
 
       - name: Run tests
         run: docker run
@@ -33,11 +56,14 @@ jobs:
           --pid host
           --shm-size 64G
           --env USE_ROCM="1"
-          --entrypoint /bin/bash
+          --volume $HOME/.cache/huggingface:/home/user/.cache/huggingface
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --device /dev/kfd
-          --device /dev/dri/card0 --device /dev/dri/renderD128
-          --device /dev/dri/card1 --device /dev/dri/renderD129
-          opt-bench-rocm:5.6.1
+          --device /dev/dri/renderD128
+          --device /dev/dri/renderD129
+          --entrypoint /bin/bash
+          opt-bench-rocm:$TORCH_ROCM_VERSION
           -c "pip install -e .[test,peft,diffusers] && pytest -k 'cuda and pytorch' -x"
+        env:
+          TORCH_ROCM_VERSION: ${{ matrix.image.torch_rocm_version }}

--- a/docker/rocm.dockerfile
+++ b/docker/rocm.dockerfile
@@ -17,7 +17,8 @@ ARG UBUNTU_VERSION=22.04
 
 FROM rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}
 
-ARG TORCH_ROCM=rocm5.6
+ARG TORCH_PRE_RELEASE=0
+ARG TORCH_ROCM_VERSION=5.6
 
 # Ignore interactive questions during `docker build`
 ENV DEBIAN_FRONTEND noninteractive
@@ -62,5 +63,9 @@ WORKDIR /home/user
 # Update pip
 RUN pip install --upgrade pip
 
-# Install PyTorch
-RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/${TORCH_ROCM}
+# Install PyTorch (nightly if ROCM_VERSION=5.7 or TORCH_PRE_RELEASE=1)
+RUN if [ "${TORCH_PRE_RELEASE}" = "1" ]; then \
+        pip install --no-cache-dir --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm${TORCH_ROCM_VERSION} ; \
+    else \
+        pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm${TORCH_ROCM_VERSION} ; \
+    fi

--- a/optimum_benchmark/import_utils.py
+++ b/optimum_benchmark/import_utils.py
@@ -14,6 +14,7 @@ _openvino_available = importlib.util.find_spec("openvino") is not None
 _neural_compressor_available = importlib.util.find_spec("neural_compressor") is not None
 _pyrsmi_available = importlib.util.find_spec("pyrsmi") is not None
 _codecarbon_available = importlib.util.find_spec("codecarbon") is not None
+_amdsmi_available = importlib.util.find_spec("amdsmi") is not None
 
 
 def is_onnx_available():
@@ -34,6 +35,10 @@ def is_py3nvml_available():
 
 def is_pyrsmi_available():
     return _pyrsmi_available
+
+
+def is_amdsmi_available():
+    return _amdsmi_available
 
 
 def is_torch_available():

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,19 @@ import subprocess
 
 from setuptools import find_packages, setup
 
-OPTIMUM_VERSION = "1.13.0"
+OPTIMUM_VERSION = "1.14.0"
 
 INSTALL_REQUIRES = [
     # Mandatory HF dependencies
     f"optimum>={OPTIMUM_VERSION}",  # backends, tasks and input generation
     "accelerate",  # distributed inference and no weights init
     # Hydra
-    "omegaconf>=2.3.0",
-    "hydra-core>=1.3.2",
-    "hydra_colorlog>=1.2.0",
+    "omegaconf",
+    "hydra-core",
+    "hydra_colorlog",
     # Other
-    "psutil>=5.9.0",
-    "pandas>=2.0.0",
+    "psutil",
+    "pandas",
 ]
 
 # We may allow to install CUDA or RoCm dependencies even when building in a non-CUDA or non-RoCm environment.
@@ -54,7 +54,7 @@ EXTRAS_REQUIRE = {
     "onnxruntime-gpu": [f"optimum[onnxruntime-gpu]>={OPTIMUM_VERSION}"],
     "onnxruntime-training": ["torch-ort", "onnxruntime-training"],
     # server-like backends
-    "text-generation-inference": ["docker>=6.1.3"],
+    "text-generation-inference": ["docker>=6.0.0"],
     # specific settings
     "diffusers": ["diffusers"],
     "peft": ["peft"],


### PR DESCRIPTION
The API for `amdsmi` is not the same starting from ROCm5.7.
- This PR adds a dispatch depending on the ROCm version.
- This PR also adds a matrix to the rocm gpus workflow to test on both rocm5.6 with latest stable `pytorch` and rocm5.7 with nightly `pytorch`.