### PR TITLE
Fix: Enable Energy Calculation in Benchmarking by Implementing Subtraction Method

### DIFF
--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -52,6 +52,19 @@ class Energy:
         LOGGER.info(f"\t\t+ {prefix} RAM energy: {self.ram:f} ({self.unit})")
         LOGGER.info(f"\t\t+ {prefix} total energy: {self.total:f} ({self.unit})")
 
+    def __sub__(self, other: "Energy") -> "Energy":
+        """Enables subtraction of two Energy instances using the '-' operator."""
+        if self.unit != other.unit:
+            raise ValueError("Energy units must match to perform subtraction")
+        
+        return Energy(
+            cpu=self.cpu - other.cpu,
+            gpu=self.gpu - other.gpu,
+            ram=self.ram - other.ram,
+            total=self.total - other.total,
+            unit=self.unit
+        )
+
 
 @dataclass
 class Efficiency:


### PR DESCRIPTION
## Background
During the development of our benchmarking system, it was discovered that calculating the net energy consumption for text generation tasks (subtracting the energy consumed during the 'forward' operation from the 'generate' operation) was not feasible with the current implementation of the `Energy` class. This limitation stemmed from the absence of a method to subtract one `Energy` instance from another.

## Solution
This pull request addresses the issue by introducing a `__sub__` method to the `Energy` class. This method enables the direct subtraction of two `Energy` instances, facilitating the accurate calculation of energy differences required for benchmarking.

## Implementation Details
- The `__sub__` method checks for unit compatibility and then subtracts the attributes (`cpu`, `gpu`, `ram`, `total`) of one `Energy` instance from another.
- This functionality is critical for the line `self.report.decode.energy = generate_energy - forward_energy` to work as intended in the benchmarking workflow.

## Impact
- With this update, the benchmarking system can now accurately report on the energy efficiency of different models by calculating the net energy consumed during text generation tasks.
