### PR TITLE
Migrate CUDA CI workflows

### DIFF
--- a/.github/workflows/test_api_cuda.yaml
+++ b/.github/workflows/test_api_cuda.yaml
@@ -44,7 +44,7 @@ jobs:
           --gpus all
           --shm-size 64G
           --env USE_CUDA="1"
-          --env TRACK_GLOBAL_VRAM="1"
+          --env PROCESS_SPECIFIC_VRAM="0"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_api_cuda.yaml
+++ b/.github/workflows/test_api_cuda.yaml
@@ -42,9 +42,9 @@ jobs:
         run: docker run
           --rm
           --gpus all
-          --pid host
           --shm-size 64G
           --env USE_CUDA="1"
+          --env TRACK_GLOBAL_VRAM="1"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_api_cuda.yaml
+++ b/.github/workflows/test_api_cuda.yaml
@@ -19,10 +19,11 @@ jobs:
         image:
           [
             { torch_cuda: cu118, torch_pre_release: 0, cuda_version: 11.8.0 },
-            { torch_cuda: cu121, torch_pre_release: 1, cuda_version: 12.1.1 },
+            { torch_cuda: cu121, torch_pre_release: 1, cuda_version: 12.1.0 },
           ]
 
-    runs-on: nvidia-gpu
+    runs-on: [multi-gpu, nvidia-gpu, 4-a10, ci]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,18 +38,13 @@ jobs:
           --tag opt-bench-cuda:${{ matrix.image.cuda_version }}
           .
 
-      - name: Get GPUs with most free memory
-        id: get_devices
-        run: |
-          echo "::set-output name=devices::$(nvidia-smi --query-gpu=memory.free,index --format=csv,noheader,nounits | sort -n -k1 | tail -n 2 | awk -F', ' '{print $2}' | xargs echo -n | sed 's/ /,/g' | awk '{print $0}')"
-
       - name: Run tests
         run: docker run
           --rm
+          --gpus all
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --gpus '"device=${{ steps.get_devices.outputs.devices }}"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_api_cuda.yaml
+++ b/.github/workflows/test_api_cuda.yaml
@@ -19,7 +19,7 @@ jobs:
         image:
           [
             { torch_cuda: cu118, torch_pre_release: 0, cuda_version: 11.8.0 },
-            { torch_cuda: cu121, torch_pre_release: 1, cuda_version: 12.1.0 },
+            { torch_cuda: cu121, torch_pre_release: 1, cuda_version: 12.1.1 },
           ]
 
     runs-on: [multi-gpu, nvidia-gpu, 4-a10, ci]

--- a/.github/workflows/test_cli_cuda_onnxruntime.yaml
+++ b/.github/workflows/test_cli_cuda_onnxruntime.yaml
@@ -33,11 +33,11 @@ jobs:
         run: docker run
           --rm
           --gpus all
-          --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --entrypoint /bin/bash
+          --env TRACK_GLOBAL_VRAM="1"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
+          --entrypoint /bin/bash
           opt-bench-cuda:11.8.0
           -c "pip install -e .[testing,onnxruntime-gpu,diffusers,timm] && pytest -k 'cli and cuda and onnxruntime' -x"

--- a/.github/workflows/test_cli_cuda_onnxruntime.yaml
+++ b/.github/workflows/test_cli_cuda_onnxruntime.yaml
@@ -13,7 +13,8 @@ concurrency:
 
 jobs:
   build_image_and_run_cli_cuda_onnxruntime_tests:
-    runs-on: nvidia-gpu
+    runs-on: [single-gpu, nvidia-gpu, a10, ci]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,19 +29,14 @@ jobs:
           --tag opt-bench-cuda:11.8.0
           .
 
-      - name: Get GPUs with most free memory
-        id: get_devices
-        run: |
-          echo "::set-output name=devices::$(nvidia-smi --query-gpu=memory.free,index --format=csv,noheader,nounits | sort -n -k1 | tail -n 2 | awk -F', ' '{print $2}' | xargs echo -n | sed 's/ /,/g' | awk '{print $0}')"
-
       - name: Run tests
         run: docker run
           --rm
+          --gpus all
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
           --entrypoint /bin/bash
-          --gpus '"device=${{ steps.get_devices.outputs.devices }}"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           opt-bench-cuda:11.8.0

--- a/.github/workflows/test_cli_cuda_onnxruntime.yaml
+++ b/.github/workflows/test_cli_cuda_onnxruntime.yaml
@@ -35,7 +35,7 @@ jobs:
           --gpus all
           --shm-size 64G
           --env USE_CUDA="1"
-          --env TRACK_GLOBAL_VRAM="1"
+          --env PROCESS_SPECIFIC_VRAM="0"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_cuda_pytorch.yaml
+++ b/.github/workflows/test_cli_cuda_pytorch.yaml
@@ -44,7 +44,7 @@ jobs:
           --gpus all
           --shm-size 64G
           --env USE_CUDA="1"
-          --env TRACK_GLOBAL_VRAM="1"
+          --env PROCESS_SPECIFIC_VRAM="0"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_cuda_pytorch.yaml
+++ b/.github/workflows/test_cli_cuda_pytorch.yaml
@@ -42,9 +42,9 @@ jobs:
         run: docker run
           --rm
           --gpus all
-          --pid host
           --shm-size 64G
           --env USE_CUDA="1"
+          --env TRACK_GLOBAL_VRAM="1"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_cuda_pytorch.yaml
+++ b/.github/workflows/test_cli_cuda_pytorch.yaml
@@ -22,7 +22,8 @@ jobs:
             { torch_cuda: cu121, torch_pre_release: 1, cuda_version: 12.1.1 },
           ]
 
-    runs-on: nvidia-gpu
+    runs-on: [multi-gpu, nvidia-gpu, 4-a10, ci]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,18 +38,13 @@ jobs:
           --tag opt-bench-cuda:${{ matrix.image.cuda_version }}
           .
 
-      - name: Get GPUs with most free memory
-        id: get_devices
-        run: |
-          echo "::set-output name=devices::$(nvidia-smi --query-gpu=memory.free,index --format=csv,noheader,nounits | sort -n -k1 | tail -n 2 | awk -F', ' '{print $2}' | xargs echo -n | sed 's/ /,/g' | awk '{print $0}')"
-
       - name: Run tests
         run: docker run
           --rm
+          --gpus all
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --gpus '"device=${{ steps.get_devices.outputs.devices }}"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_cuda_torch_ort.yaml
+++ b/.github/workflows/test_cli_cuda_torch_ort.yaml
@@ -33,11 +33,11 @@ jobs:
         run: docker run
           --rm
           --gpus all
-          --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --entrypoint /bin/bash
+          --env TRACK_GLOBAL_VRAM="1"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
+          --entrypoint /bin/bash
           opt-bench-cuda:11.8.0
           -c "pip install -e .[testing,torch-ort,peft] && python -m torch_ort.configure && pytest -k 'cli and cuda and torch_ort' -x"

--- a/.github/workflows/test_cli_cuda_torch_ort.yaml
+++ b/.github/workflows/test_cli_cuda_torch_ort.yaml
@@ -35,7 +35,7 @@ jobs:
           --gpus all
           --shm-size 64G
           --env USE_CUDA="1"
-          --env TRACK_GLOBAL_VRAM="1"
+          --env PROCESS_SPECIFIC_VRAM="0"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_cuda_torch_ort.yaml
+++ b/.github/workflows/test_cli_cuda_torch_ort.yaml
@@ -13,7 +13,8 @@ concurrency:
 
 jobs:
   build_image_and_run_cli_cuda_torch_ort_tests:
-    runs-on: nvidia-gpu
+    runs-on: [multi-gpu, nvidia-gpu, 4-a10, ci]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,19 +29,14 @@ jobs:
           --tag opt-bench-cuda:11.8.0
           .
 
-      - name: Get GPUs with most free memory
-        id: get_devices
-        run: |
-          echo "::set-output name=devices::$(nvidia-smi --query-gpu=memory.free,index --format=csv,noheader,nounits | sort -n -k1 | tail -n 2 | awk -F', ' '{print $2}' | xargs echo -n | sed 's/ /,/g' | awk '{print $0}')"
-
       - name: Run tests
         run: docker run
           --rm
+          --gpus all
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
           --entrypoint /bin/bash
-          --gpus '"device=${{ steps.get_devices.outputs.devices }}"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           opt-bench-cuda:11.8.0

--- a/.github/workflows/test_cli_tensorrt_llm.yaml
+++ b/.github/workflows/test_cli_tensorrt_llm.yaml
@@ -34,7 +34,7 @@ jobs:
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --env TRACK_GLOBAL_VRAM="1"
+          --env PROCESS_SPECIFIC_VRAM="0"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_tensorrt_llm.yaml
+++ b/.github/workflows/test_cli_tensorrt_llm.yaml
@@ -34,6 +34,7 @@ jobs:
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
+          --env TRACK_GLOBAL_VRAM="1"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_tensorrt_llm.yaml
+++ b/.github/workflows/test_cli_tensorrt_llm.yaml
@@ -13,7 +13,8 @@ concurrency:
 
 jobs:
   pull_image_and_run_cli_tensorrt_llm_tests:
-    runs-on: nvidia-gpu
+    runs-on: [single-gpu, nvidia-gpu, a10, ci]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,18 +27,13 @@ jobs:
           --tag opt-bench-tensorrt-llm:latest
           .
 
-      - name: Get GPUs with most free memory
-        id: get_devices
-        run: |
-          echo "::set-output name=devices::$(nvidia-smi --query-gpu=memory.free,index --format=csv,noheader,nounits | sort -n -k1 | tail -n 2 | awk -F', ' '{print $2}' | xargs echo -n | sed 's/ /,/g' | awk '{print $0}')"
-
       - name: Run tests
         run: docker run
           --rm
+          --gpus all
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --gpus '"device=${{ steps.get_devices.outputs.devices }}"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_tensorrt_onnxruntime.yaml
+++ b/.github/workflows/test_cli_tensorrt_onnxruntime.yaml
@@ -34,7 +34,7 @@ jobs:
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --env TRACK_GLOBAL_VRAM="1"
+          --env PROCESS_SPECIFIC_VRAM="0"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_tensorrt_onnxruntime.yaml
+++ b/.github/workflows/test_cli_tensorrt_onnxruntime.yaml
@@ -13,7 +13,8 @@ concurrency:
 
 jobs:
   build_image_and_run_cli_tensorrt_onnxruntime_tests:
-    runs-on: nvidia-gpu
+    runs-on: [single-gpu, nvidia-gpu, a10, ci]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,18 +27,13 @@ jobs:
           --tag opt-bench-tensorrt:latest
           .
 
-      - name: Get GPUs with most free memory
-        id: get_devices
-        run: |
-          echo "::set-output name=devices::$(nvidia-smi --query-gpu=memory.free,index --format=csv,noheader,nounits | sort -n -k1 | tail -n 2 | awk -F', ' '{print $2}' | xargs echo -n | sed 's/ /,/g' | awk '{print $0}')"
-
       - name: Run tests
         run: docker run
           --rm
+          --gpus all
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
-          --gpus '"device=${{ steps.get_devices.outputs.devices }}"'
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/.github/workflows/test_cli_tensorrt_onnxruntime.yaml
+++ b/.github/workflows/test_cli_tensorrt_onnxruntime.yaml
@@ -34,6 +34,7 @@ jobs:
           --pid host
           --shm-size 64G
           --env USE_CUDA="1"
+          --env TRACK_GLOBAL_VRAM="1"
           --volume $(pwd):/workspace/optimum-benchmark
           --workdir /workspace/optimum-benchmark
           --entrypoint /bin/bash

--- a/docker/cpu.dockerfile
+++ b/docker/cpu.dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:latest
+ARG UBUNTU_VERSION=20.04
+
+FROM ubuntu:${UBUNTU_VERSION}
 
 # Ignore interactive questions during `docker build`
 ENV DEBIAN_FRONTEND noninteractive

--- a/examples/pytorch_timm.yaml
+++ b/examples/pytorch_timm.yaml
@@ -18,6 +18,7 @@ launcher:
   device_isolation: true
 
 benchmark:
+  memory: true
   input_shapes:
     batch_size: 1
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,10 +44,12 @@ LIBRARIES_TASKS_MODELS = [
 LAUNCHER_CONFIGS = [
     InlineConfig(device_isolation=False),
     ProcessConfig(device_isolation=False),
-    TorchrunConfig(device_isolation=False, nproc_per_node=4),
+    TorchrunConfig(device_isolation=False, nproc_per_node=2),
 ]
 BACKENDS = ["pytorch", "none"]
 DEVICES = ["cpu", "cuda"]
+
+CUDA_VISIBLE_DEVICES = "".join([str(i) for i in range(torch.cuda.device_count())])
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -113,8 +115,7 @@ def test_api_memory_tracker(device, backend):
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("launcher_config", LAUNCHER_CONFIGS)
 def test_api_launch(device, launcher_config):
-    device_ids = "0,1,2,3" if device == "cuda" else None
-
+    device_ids = CUDA_VISIBLE_DEVICES if device == "cuda" else None
     benchmark_config = InferenceConfig(latency=True, memory=True)
     backend_config = PyTorchConfig(
         model="bert-base-uncased",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -116,7 +116,7 @@ def test_api_memory_tracker(device, backend):
 @pytest.mark.parametrize("launcher_config", LAUNCHER_CONFIGS)
 def test_api_launch(device, launcher_config):
     device_ids = CUDA_VISIBLE_DEVICES if device == "cuda" else None
-    benchmark_config = InferenceConfig(latency=True, memory=True)
+    benchmark_config = InferenceConfig(latency=True, memory=True, input_shapes={"batch_size": 4})
     backend_config = PyTorchConfig(
         model="bert-base-uncased",
         device_ids=device_ids,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,7 +44,7 @@ LIBRARIES_TASKS_MODELS = [
 LAUNCHER_CONFIGS = [
     InlineConfig(device_isolation=False),
     ProcessConfig(device_isolation=False),
-    TorchrunConfig(device_isolation=False, nproc_per_node=2),
+    TorchrunConfig(device_isolation=False, nproc_per_node=4),
 ]
 BACKENDS = ["pytorch", "none"]
 DEVICES = ["cpu", "cuda"]
@@ -113,10 +113,12 @@ def test_api_memory_tracker(device, backend):
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("launcher_config", LAUNCHER_CONFIGS)
 def test_api_launch(device, launcher_config):
+    device_ids = "0,1,2,3" if device == "cuda" else None
+
     benchmark_config = InferenceConfig(latency=True, memory=True)
     backend_config = PyTorchConfig(
         model="bert-base-uncased",
-        device_ids="0,1" if device == "cuda" else None,
+        device_ids=device_ids,
         no_weights=True,
         device=device,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,7 +49,7 @@ LAUNCHER_CONFIGS = [
 BACKENDS = ["pytorch", "none"]
 DEVICES = ["cpu", "cuda"]
 
-CUDA_VISIBLE_DEVICES = "".join([str(i) for i in range(torch.cuda.device_count())])
+CUDA_VISIBLE_DEVICES = ",".join([str(i) for i in range(torch.cuda.device_count())])
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -116,7 +116,12 @@ def test_api_memory_tracker(device, backend):
 @pytest.mark.parametrize("launcher_config", LAUNCHER_CONFIGS)
 def test_api_launch(device, launcher_config):
     device_ids = CUDA_VISIBLE_DEVICES if device == "cuda" else None
-    benchmark_config = InferenceConfig(latency=True, memory=True, input_shapes={"batch_size": 4})
+    benchmark_config = InferenceConfig(
+        memory=True,
+        latency=True,
+        input_shapes={"batch_size": 4 if device_ids is not None else 1},
+    )
+
     backend_config = PyTorchConfig(
         model="bert-base-uncased",
         device_ids=device_ids,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,7 +119,7 @@ def test_api_launch(device, launcher_config):
     benchmark_config = InferenceConfig(
         memory=True,
         latency=True,
-        input_shapes={"batch_size": 4 if device_ids is not None else 1},
+        input_shapes={"batch_size": 4},
     )
 
     backend_config = PyTorchConfig(


### PR DESCRIPTION
This PR migrates to using organization runners.
It also adds the env var `PROCESS_SPECIFIC_VRAM` which when set to 0, allows measuring vram in environments that don't have access to PID Namespaces, e.g. inside a docker container, see #154 .