### PR TITLE
set "use_cpu" to true in cpu pytorch training benchmark tests (#159)

### DIFF
--- a/optimum_benchmark/backends/pytorch/backend.py
+++ b/optimum_benchmark/backends/pytorch/backend.py
@@ -345,6 +345,12 @@ class PyTorchBackend(Backend[PyTorchConfig]):
     ) -> TrainerState:
         LOGGER.info(f"\t+ Wrapping training arguments with {TrainingArguments.__name__}")
         training_arguments = TrainingArguments(**training_arguments)
+
+        if self.config.device == "cpu":
+            assert training_arguments.use_cpu, f"""backend.device is set to {self.config.device} while use_cpu in training_arguments is set to false (default)
+            which will make the training run on gpu. Please set benchmark.training.training_arguments.use_cpu to true if the benchmark is intended to run on cpu
+            """
+
         LOGGER.info(f"\t+ Wrapping model with {Trainer.__name__}")
         trainer = Trainer(
             args=training_arguments,

--- a/tests/configs/cpu_training_pytorch_bert_sweep.yaml
+++ b/tests/configs/cpu_training_pytorch_bert_sweep.yaml
@@ -8,3 +8,7 @@ defaults:
   - _self_ # hydra 1.1 compatibility
 
 experiment_name: cpu_training_pytorch_bert_sweep
+
+benchmark:
+  training_arguments:
+    use_cpu: true

--- a/tests/configs/cpu_training_pytorch_gpt_sweep.yaml
+++ b/tests/configs/cpu_training_pytorch_gpt_sweep.yaml
@@ -8,3 +8,7 @@ defaults:
   - _self_ # hydra 1.1 compatibility
 
 experiment_name: cpu_training_pytorch_gpt_sweep
+
+benchmark:
+  training_arguments:
+    use_cpu: true


### PR DESCRIPTION
- set training_arguments.use_cpu to true so that the Trainer class runs training on the cpu instead of utilizing the available gpu