### PR TITLE
Trackers revamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ run_docker_cuda:
 	--gpus all \
 	--shm-size 64G \
 	--env USE_CUDA="1" \
-	--env PROCESS_SPECIFIC_VRAM="0" \
 	--volume $(PWD):/workspace \
 	--entrypoint /bin/bash \
 	--workdir /workspace \
@@ -59,7 +58,6 @@ run_docker_rocm:
 	--device /dev/kfd \
 	--device /dev/dri \
 	--env USE_ROCM="1" \
-	--env PROCESS_SPECIFIC_VRAM="0" \
 	--volume $(PWD):/workspace \
 	--entrypoint /bin/bash \
 	--workdir /workspace \

--- a/optimum_benchmark/experiment.py
+++ b/optimum_benchmark/experiment.py
@@ -70,7 +70,13 @@ def launch(experiment_config: ExperimentConfig) -> BenchmarkReport:
     Runs an experiment using specified launcher configuration/logic
     """
 
+    # We keep track of the main benchmark process PID to be able to
+    # track its memory usage in isolated and distributed setups
+    os.environ["BENCHMARK_PID"] = str(os.getpid())
+
     if os.environ.get("BENCHMARK_INTERFACE", "API") == "API":
+        # We launch the experiment in a temporary directory to avoid
+        # polluting the current working directory with temporary files
         LOGGER.info("Launching experiment in a temporary directory.")
         tmpdir = TemporaryDirectory()
         original_dir = os.getcwd()

--- a/optimum_benchmark/trackers/memory.py
+++ b/optimum_benchmark/trackers/memory.py
@@ -13,7 +13,7 @@ from ..import_utils import (
     is_torch_available,
     is_torch_distributed_available,
 )
-from ..system_utils import get_gpu_device_ids, is_nvidia_system, is_rocm_system
+from ..system_utils import is_nvidia_system, is_rocm_system
 
 if is_rocm_system() and is_pyrsmi_available():
     from pyrsmi import rocml
@@ -38,15 +38,13 @@ MEMORY_UNIT = "MB"
 Memory_Unit_Literal = Literal["MB"]
 
 
-PROCESS_SPECIFIC_VRAM = os.environ.get("PROCESS_SPECIFIC_VRAM", "1") == "1"
-
-
 @dataclass
 class Memory:
     unit: Memory_Unit_Literal
 
     max_ram: float
-    max_vram: Optional[float] = None
+    max_global_vram: Optional[float] = None
+    max_process_vram: Optional[float] = None
     max_reserved: Optional[float] = None
     max_allocated: Optional[float] = None
 
@@ -58,12 +56,15 @@ class Memory:
             raise ValueError("Some memory measurements are missing")
 
         unit = memories[0].unit
+
         max_ram = sum(memory.max_ram for memory in memories)
 
-        if PROCESS_SPECIFIC_VRAM:
-            max_vram = sum(memory.max_vram for memory in memories) if memories[0].max_vram is not None else None
-        else:
-            max_vram = max(memory.max_vram for memory in memories) if memories[0].max_vram is not None else None
+        max_global_vram = (
+            max(memory.max_global_vram for memory in memories) if memories[0].max_global_vram is not None else None
+        )
+        max_process_vram = (
+            max(memory.max_process_vram for memory in memories) if memories[0].max_process_vram is not None else None
+        )
 
         max_reserved = sum(memory.max_reserved for memory in memories) if memories[0].max_reserved is not None else None
         max_allocated = (
@@ -71,13 +72,20 @@ class Memory:
         )
 
         return Memory(
-            unit=unit, max_ram=max_ram, max_vram=max_vram, max_reserved=max_reserved, max_allocated=max_allocated
+            unit=unit,
+            max_ram=max_ram,
+            max_global_vram=max_global_vram,
+            max_process_vram=max_process_vram,
+            max_reserved=max_reserved,
+            max_allocated=max_allocated,
         )
 
     def log(self, prefix: str = "forward"):
         LOGGER.info(f"\t\t+ {prefix} max RAM memory: {self.max_ram:f} ({self.unit})")
-        if self.max_vram is not None:
-            LOGGER.info(f"\t\t+ {prefix} max VRAM memory: {self.max_vram:f} ({self.unit})")
+        if self.max_global_vram is not None:
+            LOGGER.info(f"\t\t+ {prefix} max global VRAM memory: {self.max_global_vram:f} ({self.unit})")
+        if self.max_process_vram is not None:
+            LOGGER.info(f"\t\t+ {prefix} max process VRAM memory: {self.max_process_vram:f} ({self.unit})")
         if self.max_reserved is not None:
             LOGGER.info(f"\t\t+ {prefix} max reserved memory: {self.max_reserved:f} ({self.unit})")
         if self.max_allocated is not None:
@@ -90,38 +98,35 @@ class MemoryTracker:
         self.backend = backend
         self.device_ids = device_ids
         self.distributed = is_torch_distributed_available() and torch.distributed.is_initialized()
+        self.monitored_pid = int(os.environ.get("BENCHMARK_PID", os.getpid()))
 
         LOGGER.info("\t+ Tracking RAM memory")
 
         if self.device == "cuda":
-            if self.device_ids is None:
-                LOGGER.warning("\t+ `device=cuda` but `device_ids` not provided. Using all available CUDA devices.")
-                self.device_ids = get_gpu_device_ids()
-
             self.device_ids = list(map(int, self.device_ids.split(",")))
             LOGGER.info(f"\t+ Tracking VRAM memory of CUDA devices: {self.device_ids}")
 
             if self.backend == "pytorch":
-                num_pytorch_devices = torch.cuda.device_count()
-                if len(self.device_ids) != num_pytorch_devices:
+                self.num_pytorch_devices = torch.cuda.device_count()
+                if len(self.device_ids) != self.num_pytorch_devices:
                     raise ValueError(
-                        "The number of CUDA devices and Pytorch CUDA devices must be the same. "
-                        f"Got {len(self.device_ids)} and {num_pytorch_devices} respectively."
+                        "The number of target CUDA devices and Pytorch's CUDA device count do not match. "
+                        f"Got {len(self.device_ids)} and {self.num_pytorch_devices} respectively."
                     )
-                LOGGER.info(f"\t+ Tracking Allocated/Reserved memory of {num_pytorch_devices} Pytorch CUDA devices")
+                LOGGER.info(
+                    f"\t+ Tracking Allocated/Reserved memory of {self.num_pytorch_devices} Pytorch CUDA devices"
+                )
 
-        self.reset()
-
-    def reset(self):
         self.max_ram_memory = 0
-        self.max_vram_memory = 0
+        self.max_global_vram_memory = 0
+        self.max_process_vram_memory = 0
         self.max_reserved_memory = 0
         self.max_allocated_memory = 0
 
     @contextmanager
     def track(self):
         if self.distributed:
-            torch.distributed.barrier(device_ids=[torch.cuda.current_device()] if self.device == "cuda" else None)
+            torch.distributed.barrier()
 
         if self.device == "cuda" and self.backend == "pytorch":
             yield from self._cuda_pytorch_memory()
@@ -131,12 +136,12 @@ class MemoryTracker:
             yield from self._cpu_memory()
 
         if self.distributed:
-            torch.distributed.barrier(device_ids=[torch.cuda.current_device()] if self.device == "cuda" else None)
+            torch.distributed.barrier()
 
     def _cuda_pytorch_memory(self):
         torch.cuda.empty_cache()
 
-        for device in range(torch.cuda.device_count()):
+        for device in range(self.num_pytorch_devices):
             try:
                 torch.cuda.reset_peak_memory_stats(device=device)
             except Exception as e:
@@ -145,18 +150,19 @@ class MemoryTracker:
         yield from self._cuda_memory()
 
         self.max_allocated_memory = sum(
-            torch.cuda.max_memory_allocated(device=device) / 1e6 for device in range(torch.cuda.device_count())
+            torch.cuda.max_memory_allocated(device=device) / 1e6 for device in range(self.num_pytorch_devices)
         )
         self.max_reserved_memory = sum(
-            torch.cuda.max_memory_reserved(device=device) / 1e6 for device in range(torch.cuda.device_count())
+            torch.cuda.max_memory_reserved(device=device) / 1e6 for device in range(self.num_pytorch_devices)
         )
 
         torch.cuda.empty_cache()
 
     def _cuda_memory(self):
         child_connection, parent_connection = Pipe()
+
         memory_process = Process(
-            target=monitor_gpu_vram_memory, args=(os.getpid(), self.device_ids, child_connection), daemon=True
+            target=monitor_gpu_vram_memory, args=(self.monitored_pid, self.device_ids, child_connection), daemon=True
         )
         memory_process.start()
         parent_connection.recv()  # wait for memory process to be ready
@@ -164,11 +170,15 @@ class MemoryTracker:
         yield from self._cpu_memory()
 
         parent_connection.send(True)
-        self.max_vram_memory = parent_connection.recv()
+        self.max_global_vram_memory = parent_connection.recv()
+        self.max_process_vram_memory = parent_connection.recv()
+        parent_connection.close()
 
     def _cpu_memory(self):
         child_connection, parent_connection = Pipe()
-        memory_process = Process(target=monitor_cpu_ram_memory, args=(os.getpid(), child_connection), daemon=True)
+        memory_process = Process(
+            target=monitor_cpu_ram_memory, args=(self.monitored_pid, child_connection), daemon=True
+        )
         memory_process.start()
         parent_connection.recv()  # wait for memory process to be ready
 
@@ -176,18 +186,25 @@ class MemoryTracker:
 
         parent_connection.send(True)
         self.max_ram_memory = parent_connection.recv()
+        parent_connection.close()
 
     def get_max_memory(self):
         if self.device == "cuda" and self.backend == "pytorch":
             return Memory(
                 unit=MEMORY_UNIT,
                 max_ram=self.max_ram_memory,
-                max_vram=self.max_vram_memory,
+                max_global_vram=self.max_global_vram_memory,
+                max_process_vram=self.max_process_vram_memory,
                 max_reserved=self.max_reserved_memory,
                 max_allocated=self.max_allocated_memory,
             )
         elif self.device == "cuda":
-            return Memory(unit=MEMORY_UNIT, max_ram=self.max_ram_memory, max_vram=self.max_vram_memory)
+            return Memory(
+                unit=MEMORY_UNIT,
+                max_ram=self.max_ram_memory,
+                max_global_vram=self.max_global_vram_memory,
+                max_process_vram=self.max_process_vram_memory,
+            )
         else:
             return Memory(unit=MEMORY_UNIT, max_ram=self.max_ram_memory)
 
@@ -210,19 +227,10 @@ def monitor_cpu_ram_memory(monitored_pid: int, connection: Connection, interval:
 
 def monitor_gpu_vram_memory(monitored_pid: int, device_ids: List[int], connection: Connection, interval: float = 0.01):
     stop = False
-    max_used_memory = 0
+    max_used_global_memory = 0
+    max_used_process_memory = 0
     monitored_process = psutil.Process(monitored_pid)
     connection.send(0)
-
-    if PROCESS_SPECIFIC_VRAM:
-        LOGGER.warning(
-            "Tracking process-specific VRAM usage. This will track the memory usage of the monitored process and its children only."
-        )
-    else:
-        LOGGER.warning(
-            "Tracking global-device VRAM usage. This will track the memory usage of monitored device(s). "
-            "Which may include memory used by other processes that are not relevant to the monitored process."
-        )
 
     if is_nvidia_system():
         if not is_pynvml_available():
@@ -234,110 +242,92 @@ def monitor_gpu_vram_memory(monitored_pid: int, device_ids: List[int], connectio
         pynvml.nvmlInit()
         devices_handles = [pynvml.nvmlDeviceGetHandleByIndex(device_id) for device_id in device_ids]
 
-        if PROCESS_SPECIFIC_VRAM:
-            while not stop:
-                used_memory = 0
-                monitored_pids = [monitored_pid] + [child.pid for child in monitored_process.children(recursive=True)]
+        while not stop:
+            used_global_memory = 0
+            used_process_memory = 0
 
-                for device_id, device_handle in zip(device_ids, devices_handles):
-                    try:
-                        device_processes = pynvml.nvmlDeviceGetComputeRunningProcesses(device_handle)
-                    except Exception as e:
-                        LOGGER.warning(f"Could not get process list for device {device_id}: {e}.")
-                        continue
+            monitored_pids = [monitored_pid] + [child.pid for child in monitored_process.children(recursive=True)]
 
-                    for device_process in device_processes:
-                        if device_process.pid in monitored_pids:
-                            used_memory += device_process.usedGpuMemory
+            for device_id, device_handle in zip(device_ids, devices_handles):
+                try:
+                    device_processes = pynvml.nvmlDeviceGetComputeRunningProcesses(device_handle)
+                except Exception as e:
+                    LOGGER.warning(f"Could not get process list for device {device_id}: {e}.")
+                    continue
 
-                max_used_memory = max(max_used_memory, used_memory)
-                stop = connection.poll(interval)
+                for device_process in device_processes:
+                    if device_process.pid in monitored_pids:
+                        used_process_memory += device_process.usedGpuMemory
 
-        else:
-            while not stop:
-                used_memory = 0
+                try:
+                    device_memory = pynvml.nvmlDeviceGetMemoryInfo(device_handle)
+                except Exception as e:
+                    LOGGER.warning(f"Could not get memory info for device {device_id}: {e}.")
+                    continue
 
-                for device_id, device_handle in zip(device_ids, devices_handles):
-                    try:
-                        device_memory = pynvml.nvmlDeviceGetMemoryInfo(device_handle)
-                    except Exception as e:
-                        LOGGER.warning(f"Could not get memory info for device {device_id}: {e}")
-                        continue
+                used_global_memory += device_memory.used
 
-                    used_memory += device_memory.used
-
-                max_used_memory = max(max_used_memory, used_memory)
-                stop = connection.poll(interval)
+            max_used_global_memory = max(max_used_global_memory, used_global_memory)
+            max_used_process_memory = max(max_used_process_memory, used_process_memory)
+            stop = connection.poll(interval)
 
         pynvml.nvmlShutdown()
 
     elif is_rocm_system():
-        if not is_amdsmi_available() and not is_pyrsmi_available():
+        if not is_amdsmi_available():
             raise ValueError(
-                "Either the library AMD SMI or PyRSMI is required to run memory benchmark on AMD GPUs, but neither is installed. "
-                "Please install the official and AMD maintained AMD SMI library from https://github.com/ROCm/amdsmi "
-                "or PyRSMI library from https://github.com/ROCm/pyrsmi."
+                "The library AMD SMI is required to track process-specific memory benchmark on AMD GPUs, but is not installed. "
+                "Please install the official and AMD maintained AMD SMI library from https://github.com/ROCm/amdsmi."
+            )
+        if not is_pyrsmi_available():
+            raise ValueError(
+                "The library PyRSMI is required to track global-device memory benchmark on AMD GPUs, but is not installed. "
+                "Please install the official and AMD maintained PyRSMI library from https://github.com/ROCm/pyrsmi."
             )
 
-        if PROCESS_SPECIFIC_VRAM:
-            if not is_amdsmi_available():
-                raise ValueError(
-                    "The library AMD SMI is required to run process-specific memory benchmark on AMD GPUs, but is not installed. "
-                    "Please install the official and AMD maintained AMD SMI library from https://github.com/ROCm/amdsmi."
-                )
+        amdsmi.amdsmi_init()
+        rocml.smi_initialize()
+        devices_handles = amdsmi.amdsmi_get_processor_handles()
 
-            amdsmi.amdsmi_init()
-            devices_handles = amdsmi.amdsmi_get_processor_handles()
-            while not stop:
-                used_memory = 0
-                monitored_pids = [monitored_pid] + [child.pid for child in monitored_process.children(recursive=True)]
+        while not stop:
+            used_global_memory = 0
+            used_process_memory = 0
 
-                for device_id in device_ids:
-                    device_handle = devices_handles[device_id]
+            monitored_pids = [monitored_pid] + [child.pid for child in monitored_process.children(recursive=True)]
+
+            for device_id in device_ids:
+                device_handle = devices_handles[device_id]
+                try:
+                    processes_handles = amdsmi.amdsmi_get_gpu_process_list(device_handle)
+                except Exception as e:
+                    LOGGER.warning(f"Could not get process list for device {device_id}: {e}")
+                    continue
+
+                for process_handle in processes_handles:
                     try:
-                        processes_handles = amdsmi.amdsmi_get_gpu_process_list(device_handle)
+                        gpu_process_info = amdsmi.amdsmi_get_gpu_process_info(device_handle, process_handle)
                     except Exception as e:
-                        LOGGER.warning(f"Could not get process list for device {device_id}: {e}")
+                        LOGGER.warning(f"Could not get process info for process {process_handle}: {e}")
                         continue
 
-                    for process_handle in processes_handles:
-                        try:
-                            gpu_process_info = amdsmi.amdsmi_get_gpu_process_info(device_handle, process_handle)
-                        except Exception as e:
-                            LOGGER.warning(f"Could not get process info for process {process_handle}: {e}")
-                            continue
+                    if gpu_process_info["pid"] in monitored_pids:
+                        max_used_process_memory += gpu_process_info["memory_usage"]["vram_mem"]
 
-                        if gpu_process_info["pid"] in monitored_pids:
-                            used_memory += gpu_process_info["memory_usage"]["vram_mem"]
+                try:
+                    used_global_memory += rocml.smi_get_device_memory_used(device_id)
+                except Exception as e:
+                    LOGGER.warning(f"Could not get memory usage for device {device_id}: {e}")
 
-                max_used_memory = max(max_used_memory, used_memory)
-                stop = connection.poll(interval)
+            max_used_global_memory = max(max_used_global_memory, used_global_memory)
+            max_used_process_memory = max(max_used_process_memory, used_process_memory)
+            stop = connection.poll(interval)
 
-            amdsmi.amdsmi_shut_down()
-
-        else:
-            if not is_pyrsmi_available():
-                raise ValueError(
-                    "The library PyRSMI is required to run global-device memory benchmark on AMD GPUs, but is not installed. "
-                    "Please install the official and AMD maintained PyRSMI library from https://github.com/ROCm/pyrsmi."
-                )
-
-            rocml.smi_initialize()
-            while not stop:
-                used_memory = 0
-                for device_id in device_ids:
-                    try:
-                        used_memory += rocml.smi_get_device_memory_used(device_id)
-                    except Exception as e:
-                        LOGGER.warning(f"Could not get memory usage for device {device_id}: {e}")
-
-                max_used_memory = max(max_used_memory, used_memory)
-                stop = connection.poll(interval)
-
-            rocml.smi_shutdown()
+        amdsmi.amdsmi_shut_down()
+        rocml.smi_shutdown()
 
     else:
-        raise ValueError("Only NVIDIA and AMD ROCm GPUs are supported for CUDA memory tracking.")
+        raise ValueError("Only NVIDIA and AMD ROCm GPUs are supported for VRAM tracking.")
 
-    connection.send(max_used_memory / 1e6)  # convert to MB
+    connection.send(max_used_global_memory / 1e6)  # convert to MB
+    connection.send(max_used_process_memory / 1e6)  # convert to MB
     connection.close()

--- a/setup.py
+++ b/setup.py
@@ -41,14 +41,13 @@ USE_ROCM = (os.environ.get("USE_ROCM", None) == "1") or IS_ROCM_SYSTEM
 if USE_CUDA:
     INSTALL_REQUIRES.append("nvidia-ml-py")
 
-PYRSMI = "pyrsmi@git+https://github.com/ROCm/pyrsmi.git"
 if USE_ROCM:
+    PYRSMI = "pyrsmi@git+https://github.com/ROCm/pyrsmi.git"
     INSTALL_REQUIRES.append(PYRSMI)
     if not importlib.util.find_spec("amdsmi"):
         print(
             "ROCm GPU detected without amdsmi installed. You won't be able to run process-specific VRAM tracking. "
-            "Please install amdsmi from https://github.com/ROCm/amdsmi to enable this feature, "
-            "or remember to set PROCESS_SPECIFIC_VRAM=0 in your environment to disable it."
+            "Please install amdsmi from https://github.com/ROCm/amdsmi to enable this feature."
         )
 
 AUTOGPTQ_CUDA = "auto-gptq==0.7.1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,17 +39,6 @@ LIBRARIES_TASKS_MODELS = [
 ]
 
 
-def delete_all_tensors():
-    for obj in gc.get_objects():
-        if torch.is_tensor(obj):
-            del obj
-
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-
-    gc.collect()
-
-
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("benchmark", ["training", "inference"])
 @pytest.mark.parametrize("library,task,model", LIBRARIES_TASKS_MODELS)
@@ -164,6 +153,7 @@ def test_api_latency_tracker(device, backend):
 
     assert latency.mean < 1.1
     assert latency.mean > 0.9
+    assert len(latency.values) == 2
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
@@ -177,7 +167,6 @@ def test_api_memory_tracker(device, backend):
         time.sleep(1)
         pass
 
-    # the process consumes memory that we can't control
     initial_memory = tracker.get_max_memory()
     initial_memory.log()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ from optimum_benchmark.generators.input_generator import InputGenerator
 from optimum_benchmark.import_utils import get_git_revision_hash
 from optimum_benchmark.launchers.process.config import ProcessConfig
 from optimum_benchmark.system_utils import get_gpu_device_ids
-from optimum_benchmark.trackers.latency import LatencyTracker
+from optimum_benchmark.trackers.latency import LatencyTracker, Timer
 from optimum_benchmark.trackers.memory import MemoryTracker
 
 LIBRARIES_TASKS_MODELS = [
@@ -37,6 +37,17 @@ LIBRARIES_TASKS_MODELS = [
     ("transformers", "image-classification", "google/vit-base-patch16-224"),
     ("diffusers", "stable-diffusion", "CompVis/stable-diffusion-v1-4"),
 ]
+
+
+def delete_all_tensors():
+    for obj in gc.get_objects():
+        if torch.is_tensor(obj):
+            del obj
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    gc.collect()
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
@@ -133,31 +144,33 @@ def test_api_dataset_generator(library, task, model):
     generated_dataset = generator()
 
     assert len(generated_dataset) > 0, "No dataset was generated"
-
-    len(generated_dataset) == DATASET_SHAPES["dataset_size"]
+    assert len(generated_dataset) == DATASET_SHAPES["dataset_size"]
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("backend", ["pytorch", "other"])
 def test_api_latency_tracker(device, backend):
-    expected_latency = 1
     tracker = LatencyTracker(device=device, backend=backend)
+    timer = Timer()
 
-    for _ in range(2):
+    timer.reset()
+    tracker.reset()
+    while timer.elapsed() < 2:
         with tracker.track():
             time.sleep(1)
 
     latency = tracker.get_latency()
     latency.log()
 
-    assert latency.mean < expected_latency * 1.1
-    assert latency.mean > expected_latency * 0.9
+    assert latency.mean < 1.1
+    assert latency.mean > 0.9
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("backend", ["pytorch", "other"])
 def test_api_memory_tracker(device, backend):
-    tracker = MemoryTracker(device=device, backend=backend)
+    device_ids = get_gpu_device_ids() if device == "cuda" else None
+    tracker = MemoryTracker(device=device, backend=backend, device_ids=device_ids)
 
     tracker.reset()
     with tracker.track():
@@ -182,9 +195,8 @@ def test_api_memory_tracker(device, backend):
         if backend == "pytorch":
             measured_memory = final_memory.max_allocated - initial_memory.max_allocated
         else:
-            if torch.version.hip is not None:
-                return  # skip vram measurement for ROCm
-            measured_memory = final_memory.max_vram - initial_memory.max_vram
+            # because user namespace is not visible to pynvml/amdsmi, we use global vram
+            measured_memory = final_memory.max_global_vram - initial_memory.max_global_vram
     else:
         measured_memory = final_memory.max_ram - initial_memory.max_ram
 


### PR DESCRIPTION
- Standardizing the latency trackers and making them only track, the timing is handled by a separate class `Timer`.
- Making the memory tracker more robust when used with `launch`, by monitoring the main benchmark process (so no need to aggregate VRAM over multiple processes) and supporting both per process and global VRAM tracking at the same time.