### PR TITLE
Add t4 for llm perf leaderboard

### DIFF
--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         subset: [unquantized, bnb, awq, gptq]
-        # { name: 1xA10, runs-on: [aws-g5-4xlarge-plus] }, 
-        machine: [{ name: 1xT4, runs-on: aws-g4dn-2xlarge }]
+        # { name: 1xA10, runs-on: ... }, 
+        machine: [{ name: 1xT4, runs-on: { group: 'aws-g4dn-2xlarge' } }]
 
     runs-on: ${{ matrix.machine.runs-on }}
 

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -1,12 +1,9 @@
 name: Update LLM Perf Benchmarks - CUDA PyTorch
 
-on: workflow_dispatch
-  # push:
-  #   branches:
-  #     - "add-t4-for-llm-perf-leaderboard"
-  # For debugging purpose the workflow is triggered manually
-  # schedule:
-  #   - cron: "0 */6 * * *"
+on: 
+  workflow_dispatch:  # Manual trigger
+  release:            # Trigger on new release
+    types: [published]  
 
 concurrency:
   cancel-in-progress: true
@@ -23,7 +20,7 @@ jobs:
         subset: [unquantized, bnb, awq, gptq]
         
         machine: [
-        # {name: 1xA10, runs-on: {group: 'aws-g5-4xlarge-plus'}}, 
+          {name: 1xA10, runs-on: {group: 'aws-g5-4xlarge-plus'}}, 
           {name: 1xT4, runs-on: {group: 'aws-g4dn-2xlarge'}}
         ]
 

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -3,7 +3,7 @@ name: Update LLM Perf Benchmarks - CUDA PyTorch
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" 
+    - cron: "0 0 * * *"
 
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -1,7 +1,6 @@
 name: Update LLM Perf Benchmarks - CUDA PyTorch
 
-on:
-  push:
+on: push
   # For debugging purpose the workflow is triggered manually
   # schedule:
   #   - cron: "0 */6 * * *"

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         subset: [unquantized, bnb, awq, gptq]
         # { name: 1xA10, runs-on: [aws-g5-4xlarge-plus] }, 
-        machine: [{ name: 1xT4, runs-on: [aws-g4dn-2xlarge] }]
+        machine: [{ name: 1xT4, runs-on: aws-g4dn-2xlarge }]
 
     runs-on: ${{ matrix.machine.runs-on }}
 

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -1,8 +1,8 @@
 name: Update LLM Perf Benchmarks - CUDA PyTorch
 
-on: 
-  workflow_dispatch:  
-  release:            
+on:
+  workflow_dispatch:
+  release:
     types: [published]  
 
 concurrency:

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -1,8 +1,8 @@
 name: Update LLM Perf Benchmarks - CUDA PyTorch
 
 on: 
-  workflow_dispatch:  # Manual trigger
-  release:            # Trigger on new release
+  workflow_dispatch:  
+  release:            
     types: [published]  
 
 concurrency:

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -21,8 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         subset: [unquantized, bnb, awq, gptq]
-        # { name: 1xA10, runs-on: ... }, 
-        machine: [{ name: 1xT4, runs-on: { group: 'aws-g4dn-2xlarge' } }]
+        
+        machine: [
+        # {name: 1xA10, runs-on: {group: 'aws-g5-4xlarge-plus'}}, 
+          {name: 1xT4, runs-on: {group: 'aws-g4dn-2xlarge'}}
+        ]
 
     runs-on: ${{ matrix.machine.runs-on }}
 

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         subset: [unquantized, bnb, awq, gptq]
-        machine: [{ name: 1xA10, runs-on: [single-gpu, nvidia-gpu, a10, ci] }]
+        machine: [{ name: 1xA10, runs-on: [single-gpu, nvidia-gpu, a10, ci] }, { name: 1xT4, runs-on: [single-gpu, nvidia-gpu, t4, ci] }]
 
     runs-on: ${{ matrix.machine.runs-on }}
 

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -1,7 +1,9 @@
 name: Update LLM Perf Benchmarks - CUDA PyTorch
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "add-t4-for-llm-perf-leaderboard"
   # For debugging purpose the workflow is triggered manually
   # schedule:
   #   - cron: "0 */6 * * *"

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -2,8 +2,8 @@ name: Update LLM Perf Benchmarks - CUDA PyTorch
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]  
+  schedule:
+    - cron: "0 0 * * *" 
 
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -2,8 +2,6 @@ name: Update LLM Perf Benchmarks - CUDA PyTorch
 
 on:
   push:
-    branches:
-      - "add-t4-for-llm-perf-leaderboard"
   # For debugging purpose the workflow is triggered manually
   # schedule:
   #   - cron: "0 */6 * * *"

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -2,8 +2,9 @@ name: Update LLM Perf Benchmarks - CUDA PyTorch
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+  # For debugging purpose the workflow is triggered manually
+  # schedule:
+  #   - cron: "0 */6 * * *"
 
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         subset: [unquantized, bnb, awq, gptq]
-        # { name: 1xA10, runs-on: [single-gpu, nvidia-gpu, a10, ci] }, 
-        machine: [{ name: 1xT4, runs-on: [single-gpu, nvidia-gpu, t4, ci] }]
+        # { name: 1xA10, runs-on: [aws-g5-4xlarge-plus] }, 
+        machine: [{ name: 1xT4, runs-on: [aws-g4dn-2xlarge] }]
 
     runs-on: ${{ matrix.machine.runs-on }}
 

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -1,6 +1,9 @@
 name: Update LLM Perf Benchmarks - CUDA PyTorch
 
-on: push
+on: workflow_dispatch
+  # push:
+  #   branches:
+  #     - "add-t4-for-llm-perf-leaderboard"
   # For debugging purpose the workflow is triggered manually
   # schedule:
   #   - cron: "0 */6 * * *"

--- a/.github/workflows/update_llm_perf_cuda_pytorch.yaml
+++ b/.github/workflows/update_llm_perf_cuda_pytorch.yaml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         subset: [unquantized, bnb, awq, gptq]
-        machine: [{ name: 1xA10, runs-on: [single-gpu, nvidia-gpu, a10, ci] }, { name: 1xT4, runs-on: [single-gpu, nvidia-gpu, t4, ci] }]
+        # { name: 1xA10, runs-on: [single-gpu, nvidia-gpu, a10, ci] }, 
+        machine: [{ name: 1xT4, runs-on: [single-gpu, nvidia-gpu, t4, ci] }]
 
     runs-on: ${{ matrix.machine.runs-on }}
 

--- a/llm_perf/update_llm_perf_cuda_pytorch.py
+++ b/llm_perf/update_llm_perf_cuda_pytorch.py
@@ -134,7 +134,7 @@ def benchmark_cuda_pytorch(model, attn_implementation, weights_config):
         quantization_scheme=quant_scheme,
         quantization_config=quant_config,
         attn_implementation=attn_implementation,
-        hub_kwargs={"trust_remote_code": True},
+        model_kwargs={"trust_remote_code": True},
     )
 
     benchmark_config = BenchmarkConfig(

--- a/llm_perf/update_llm_perf_leaderboard.py
+++ b/llm_perf/update_llm_perf_leaderboard.py
@@ -32,7 +32,7 @@ def gather_benchmarks(subset: str, machine: str):
 
 def update_perf_dfs():
     for subset in ["unquantized", "bnb", "awq", "gptq"]:
-        for machine in ["1xA10", "1xA100"]:
+        for machine in ["1xA10", "1xA100", "1xT4"]:
             try:
                 gather_benchmarks(subset, machine)
             except Exception:

--- a/llm_perf/utils.py
+++ b/llm_perf/utils.py
@@ -44,8 +44,8 @@ PRETRAINED_OPEN_LLM_LIST = (
 #     model for model in PRETRAINED_OPEN_LLM_LIST if model.split("/")[0] in CANONICAL_ORGANIZATIONS
 # ]
 CANONICAL_PRETRAINED_OPEN_LLM_LIST = [
-    "01-ai/Yi-6B",
-    "01-ai/Yi-34B",
+    # "01-ai/Yi-6B",
+    # "01-ai/Yi-34B",
     "Deci/DeciLM-7B",
     "Deci/DeciCoder-1b",
     "EleutherAI/gpt-j-6b",

--- a/llm_perf/utils.py
+++ b/llm_perf/utils.py
@@ -44,8 +44,8 @@ PRETRAINED_OPEN_LLM_LIST = (
 #     model for model in PRETRAINED_OPEN_LLM_LIST if model.split("/")[0] in CANONICAL_ORGANIZATIONS
 # ]
 CANONICAL_PRETRAINED_OPEN_LLM_LIST = [
-    # "01-ai/Yi-6B",
-    # "01-ai/Yi-34B",
+    "01-ai/Yi-6B",
+    "01-ai/Yi-34B",
     "Deci/DeciLM-7B",
     "Deci/DeciCoder-1b",
     "EleutherAI/gpt-j-6b",

--- a/optimum_benchmark/backends/config.py
+++ b/optimum_benchmark/backends/config.py
@@ -73,6 +73,7 @@ class BackendConfig(ABC):
                 self.library,
                 revision=self.model_kwargs.get("revision", None),
                 token=self.model_kwargs.get("token", None),
+                trust_remote_code=self.model_kwargs.get("trust_remote_code", False),
             )
 
         if self.device is None:

--- a/optimum_benchmark/task_utils.py
+++ b/optimum_benchmark/task_utils.py
@@ -190,6 +190,7 @@ def infer_model_type_from_model_name_or_path(
     library_name: Optional[str] = None,
     revision: Optional[str] = None,
     token: Optional[str] = None,
+    trust_remote_code: bool = False,
 ) -> str:
     if library_name is None:
         library_name = infer_library_from_model_name_or_path(model_name_or_path, revision=revision, token=token)
@@ -216,7 +217,9 @@ def infer_model_type_from_model_name_or_path(
                 break
 
     else:
-        transformers_config = get_transformers_pretrained_config(model_name_or_path, revision=revision, token=token)
+        transformers_config = get_transformers_pretrained_config(
+            model_name_or_path, revision=revision, token=token, trust_remote_code=trust_remote_code
+        )
         inferred_model_type = transformers_config.model_type
 
     if inferred_model_type is None:


### PR DESCRIPTION
## Summary

This PR adds Nvidia T4 to the LLM-Perf Leaderboard:

### Fixes
- Fixed the `trust_remote_code` issue that was broken for the CI/CD pipeline.

### Features
- Added a new machine configuration (T4) to run the LLM performance benchmarking code.
- Updated the A100 configuration to use the new `runs-on` definition (without tags).

### Related PRs and Discussions
- [huggingface/optimum-benchmark#239](https://github.com/huggingface/optimum-benchmark/pull/239)
- [Discussion #30](https://huggingface.co/spaces/optimum/llm-perf-leaderboard/discussions/30)

### Workflow Trigger Changes
One thing that I am unsure about is that I modified the trigger for the workflow. To reduce unnecessary compute, you can manually trigger the workflow, and it is triggered with each new release of the repo ([releases](https://github.com/huggingface/optimum-benchmark/releases)).

I think this could be better. What do you think, @IlyasMoutawwakil?