### PR TITLE
Fix issue with CodeCarbon lock

### DIFF
--- a/optimum_benchmark/hub_utils.py
+++ b/optimum_benchmark/hub_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 from flatten_dict import flatten, unflatten
 from huggingface_hub import create_repo, hf_hub_download, upload_file
-from huggingface_hub.utils._errors import HfHubHTTPError
+from huggingface_hub.utils import HfHubHTTPError
 from typing_extensions import Self
 
 LOGGER = getLogger("hub_utils")

--- a/optimum_benchmark/scenarios/inference/scenario.py
+++ b/optimum_benchmark/scenarios/inference/scenario.py
@@ -187,6 +187,7 @@ class InferenceScenario(Scenario[InferenceConfig]):
             self.report.load.memory = memory_tracker.get_max_memory()
         if self.config.energy:
             self.report.load.energy = energy_tracker.get_energy()
+            energy_tracker.stop()
 
     ## Memory tracking
     def run_text_generation_memory_tracking(self, backend: Backend[BackendConfigT]):
@@ -367,6 +368,7 @@ class InferenceScenario(Scenario[InferenceConfig]):
         self.report.decode.efficiency = Efficiency.from_energy(
             decode_energy, decode_volume, unit=TEXT_GENERATION_EFFICIENCY_UNIT
         )
+        energy_tracker.stop()
 
     def run_image_diffusion_energy_tracking(self, backend: Backend[BackendConfigT]):
         self.logger.info("\t+ Running Image Diffusion energy tracking")
@@ -391,6 +393,7 @@ class InferenceScenario(Scenario[InferenceConfig]):
         self.report.call.efficiency = Efficiency.from_energy(
             call_energy, call_volume, unit=IMAGE_DIFFUSION_EFFICIENCY_UNIT
         )
+        energy_tracker.stop()
 
     def run_inference_energy_tracking(self, backend: Backend[BackendConfigT]):
         self.logger.info("\t+ Running energy tracking")
@@ -415,6 +418,7 @@ class InferenceScenario(Scenario[InferenceConfig]):
         self.report.forward.efficiency = Efficiency.from_energy(
             forward_energy, forward_volume, unit=INFERENCE_EFFICIENCY_UNIT
         )
+        energy_tracker.stop()
 
     @property
     def atomic_forward_volume(self) -> int:  # in samples

--- a/optimum_benchmark/scenarios/training/scenario.py
+++ b/optimum_benchmark/scenarios/training/scenario.py
@@ -97,6 +97,7 @@ class TrainingScenario(Scenario[TrainingConfig]):
             self.report.overall.efficiency = Efficiency.from_energy(
                 self.report.overall.energy, volume=self.overall_volume, unit=TRAIN_EFFICIENCY_UNIT
             )
+            energy_tracker.stop()
 
         return self.report
 

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -195,3 +195,6 @@ class EnergyTracker:
         return Energy(
             unit=ENERGY_UNIT, cpu=self.cpu_energy, gpu=self.gpu_energy, ram=self.ram_energy, total=self.total_energy
         )
+
+    def stop(self):
+        self.emission_tracker.stop()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ INSTALL_REQUIRES = [
     "flatten_dict",
     "colorlog",
     "pandas",
+    "huggingface_hub >= 0.25.0",
 ]
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ INSTALL_REQUIRES = [
     "flatten_dict",
     "colorlog",
     "pandas",
-    "huggingface_hub >= 0.25.0",
 ]
 
 try:


### PR DESCRIPTION
From CodeCarbon v2.7, a lock file is introduced (see [here](https://github.com/mlco2/codecarbon/blob/v2.7.0/codecarbon/emissions_tracker.py#L638)) to check whether another instance of codecarbon is running. If yes, an error is raised. One has to call `my_energy_tracker.stop()` to release the lock file.

This PR adds a `stop` method in the `EnergyTracker` class that should be called once the energy tracker is not needed anymore.
It also updates an import from `huggingface_hub` since v0.25 introduced a change (the new import is backward-compatible).

Fixes https://github.com/huggingface/optimum-benchmark/issues/260.