### PR TITLE
Set is_distributed false by default in vllm

### DIFF
--- a/optimum_benchmark/trackers/latency.py
+++ b/optimum_benchmark/trackers/latency.py
@@ -121,7 +121,8 @@ class LatencyTracker:
         self.device = device
         self.backend = backend
         self.is_asynchronous = self.backend == "pytorch" and self.device == "cuda"
-        self.is_distributed = is_torch_distributed_available() and torch.distributed.is_initialized()
+        self.is_distributed = (self.backend != "vllm" and
+                               is_torch_distributed_available() and torch.distributed.is_initialized())
 
         if self.is_asynchronous:
             LOGGER.info("\t+ Tracking latency using Pytorch CUDA events")


### PR DESCRIPTION
Fixes #251 error (vLLM AMD GPU parallelism timeout error).

Seems `is_distributed ` was set to `True` in case of vLLM parallel inference, which caused deadlock and memory leak. Adding an additional condition to prevent it from being set to `True` solved the issue.

Logs (2xMI210, Llama 3 8B):  [vllm_2gpus.log](https://github.com/user-attachments/files/17072619/vllm_2gpus.log)
