### PR TITLE
ipex backend enhancements

### DIFF
--- a/examples/ipex_bert.yaml
+++ b/examples/ipex_bert.yaml
@@ -23,7 +23,7 @@ scenario:
 
 backend:
   device: cpu
-  no_weights: true
+  no_weights: false
   export: true
   torch_dtype: bfloat16
   model: bert-base-uncased

--- a/examples/ipex_llama.yaml
+++ b/examples/ipex_llama.yaml
@@ -32,6 +32,6 @@ scenario:
 backend:
   device: cpu
   export: true
-  no_weights: true
+  no_weights: false
   torch_dtype: bfloat16
   model: TinyLlama/TinyLlama-1.1B-Chat-v1.0

--- a/optimum_benchmark/backends/ipex/utils.py
+++ b/optimum_benchmark/backends/ipex/utils.py
@@ -1,6 +1,7 @@
 TASKS_TO_IPEXMODEL = {
     "fill-mask": "optimum.intel.IPEXModelForMaskedLM",
     "text-generation": "optimum.intel.IPEXModelForCausalLM",
+    "feature-extraction": "optimum.intel.IPEXModel",
     "text-classification": "optimum.intel.IPEXModelForSequenceClassification",
     "token-classification": "optimum.intel.IPEXModelForTokenClassification",
     "question-answering": "optimum.intel.IPEXModelForQuestionAnswering",


### PR DESCRIPTION
1. add feature-extraction task mapping for ipex backend, to support embedding models benchmark
2. change examples' no_weight to false, no_weight will allocate weight buffers and random initialize them, which will ruin performance in numa cases, 2x perf drop for decoding phases