### PR TITLE
Markdown Report

### DIFF
--- a/examples/_base_.yaml
+++ b/examples/_base_.yaml
@@ -1,3 +1,6 @@
+log_report: true
+print_report: true
+
 # hydra/cli specific settings
 hydra:
   run:

--- a/examples/pytorch_bert.py
+++ b/examples/pytorch_bert.py
@@ -1,23 +1,45 @@
+import os
+
+from huggingface_hub import whoami
+
 from optimum_benchmark import Benchmark, BenchmarkConfig, InferenceConfig, ProcessConfig, PyTorchConfig
 from optimum_benchmark.logging_utils import setup_logging
 
-setup_logging(level="INFO", prefix="MAIN-PROCESS")
+try:
+    USERNAME = whoami()["name"]
+except Exception as e:
+    print(f"Failed to get username from Hugging Face Hub: {e}")
+    USERNAME = None
 
-if __name__ == "__main__":
-    BENCHMARK_NAME = "pytorch_bert"
-    REPO_ID = f"IlyasMoutawwakil/{BENCHMARK_NAME}"
+BENCHMARK_NAME = "pytorch_bert"
 
+
+def run_benchmark():
     launcher_config = ProcessConfig(device_isolation=True, device_isolation_action="warn")
     backend_config = PyTorchConfig(device="cuda", device_ids="0", no_weights=True, model="bert-base-uncased")
     scenario_config = InferenceConfig(memory=True, latency=True, input_shapes={"batch_size": 1, "sequence_length": 128})
-
     benchmark_config = BenchmarkConfig(
-        name=BENCHMARK_NAME, launcher=launcher_config, backend=backend_config, scenario=scenario_config
+        name=BENCHMARK_NAME,
+        launcher=launcher_config,
+        scenario=scenario_config,
+        backend=backend_config,
+        print_report=True,
+        log_report=True,
     )
-    # benchmark_config.push_to_hub(repo_id=REPO_ID)
-
     benchmark_report = Benchmark.launch(benchmark_config)
-    # benchmark_report.push_to_hub(repo_id=REPO_ID)
 
+    return benchmark_config, benchmark_report
+
+
+if __name__ == "__main__":
+    level = os.environ.get("LOG_LEVEL", "INFO")
+    to_file = os.environ.get("LOG_TO_FILE", "0") == "1"
+    setup_logging(level=level, to_file=to_file, prefix="MAIN-PROCESS")
+
+    benchmark_config, benchmark_report = run_benchmark()
     benchmark = Benchmark(config=benchmark_config, report=benchmark_report)
-    # benchmark.push_to_hub(repo_id=REPO_ID)
+
+    if USERNAME is not None:
+        benchmark_config.push_to_hub(repo_id=f"{USERNAME}/benchmarks", subfolder=BENCHMARK_NAME)
+        benchmark_report.push_to_hub(repo_id=f"{USERNAME}/benchmarks", subfolder=BENCHMARK_NAME)
+        benchmark.push_to_hub(repo_id=f"{USERNAME}/benchmarks", subfolder=BENCHMARK_NAME)

--- a/optimum_benchmark/backends/diffusers_utils.py
+++ b/optimum_benchmark/backends/diffusers_utils.py
@@ -39,12 +39,18 @@ TASKS_TO_MODEL_LOADERS = {
 
 
 def get_diffusers_pretrained_config(model: str, **kwargs) -> Dict[str, int]:
+    if not is_diffusers_available():
+        raise ImportError("diffusers is not available. Please, pip install diffusers.")
+
     config = DiffusionPipeline.load_config(model, **kwargs)
     pipeline_config = config[0] if isinstance(config, tuple) else config
     return pipeline_config
 
 
 def extract_diffusers_shapes_from_model(model: str, **kwargs) -> Dict[str, int]:
+    if not is_diffusers_available():
+        raise ImportError("diffusers is not available. Please, pip install diffusers.")
+
     model_config = get_diffusers_pretrained_config(model, **kwargs)
 
     shapes = {}
@@ -52,6 +58,14 @@ def extract_diffusers_shapes_from_model(model: str, **kwargs) -> Dict[str, int]:
         vae_import_path = model_config["vae"]
         vae_class = get_class(f"{vae_import_path[0]}.{vae_import_path[1]}")
         vae_config = vae_class.load_config(model, subfolder="vae", **kwargs)
+        shapes["num_channels"] = vae_config["out_channels"]
+        shapes["height"] = vae_config["sample_size"]
+        shapes["width"] = vae_config["sample_size"]
+
+    elif "vae_decoder" in model_config:
+        vae_import_path = model_config["vae_decoder"]
+        vae_class = get_class(f"{vae_import_path[0]}.{vae_import_path[1]}")
+        vae_config = vae_class.load_config(model, subfolder="vae_decoder", **kwargs)
         shapes["num_channels"] = vae_config["out_channels"]
         shapes["height"] = vae_config["sample_size"]
         shapes["width"] = vae_config["sample_size"]
@@ -74,6 +88,9 @@ def extract_diffusers_shapes_from_model(model: str, **kwargs) -> Dict[str, int]:
 
 
 def get_diffusers_automodel_loader_for_task(task: str):
+    if not is_diffusers_available():
+        raise ImportError("diffusers is not available. Please, pip install diffusers.")
+
     model_loader_name = TASKS_TO_MODEL_LOADERS[task]
     model_loader_class = getattr(diffusers, model_loader_name)
     return model_loader_class

--- a/optimum_benchmark/backends/onnxruntime/backend.py
+++ b/optimum_benchmark/backends/onnxruntime/backend.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import torch
 from hydra.utils import get_class
 from onnxruntime import SessionOptions
+from optimum.exporters.onnx.utils import MODEL_TYPES_REQUIRING_POSITION_IDS
 from optimum.onnxruntime import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
@@ -299,9 +300,8 @@ class ORTBackend(Backend[ORTConfig]):
 
         if self.config.library == "transformers":
             for key, value in list(inputs.items()):
-                if key in ["position_ids", "token_type_ids"]:
-                    if key not in self.pretrained_model.input_names:
-                        inputs.pop(key)
+                if key == "position_ids" and self.model_type not in MODEL_TYPES_REQUIRING_POSITION_IDS:
+                    inputs.pop(key)
 
         for key, value in inputs.items():
             if isinstance(value, torch.Tensor):

--- a/optimum_benchmark/backends/onnxruntime/backend.py
+++ b/optimum_benchmark/backends/onnxruntime/backend.py
@@ -6,7 +6,6 @@ from typing import Any, Dict
 import torch
 from hydra.utils import get_class
 from onnxruntime import SessionOptions
-from optimum.exporters.onnx.utils import MODEL_TYPES_REQUIRING_POSITION_IDS
 from optimum.onnxruntime import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
@@ -298,10 +297,9 @@ class ORTBackend(Backend[ORTConfig]):
             with Accelerator().split_between_processes(inputs=inputs, apply_padding=False) as process_inputs:
                 inputs = process_inputs
 
-        if self.config.library == "transformers":
-            for key, value in list(inputs.items()):
-                if key == "position_ids" and self.model_type not in MODEL_TYPES_REQUIRING_POSITION_IDS:
-                    inputs.pop(key)
+        for key in list(inputs.keys()):
+            if key not in self.pretrained_model.input_names:
+                inputs.pop(key)
 
         for key, value in inputs.items():
             if isinstance(value, torch.Tensor):

--- a/optimum_benchmark/backends/onnxruntime/backend.py
+++ b/optimum_benchmark/backends/onnxruntime/backend.py
@@ -298,7 +298,7 @@ class ORTBackend(Backend[ORTConfig]):
                 inputs = process_inputs
 
         for key in list(inputs.keys()):
-            if key not in self.pretrained_model.input_names:
+            if hasattr(self.pretrained_model, "input_names") and key not in self.pretrained_model.input_names:
                 inputs.pop(key)
 
         for key, value in inputs.items():

--- a/optimum_benchmark/backends/openvino/backend.py
+++ b/optimum_benchmark/backends/openvino/backend.py
@@ -202,7 +202,7 @@ class OVBackend(Backend[OVConfig]):
                 inputs = process_inputs
 
         for key in list(inputs.keys()):
-            if key not in self.pretrained_model.input_names:
+            if hasattr(self.pretrained_model, "input_names") and key not in self.pretrained_model.input_names:
                 inputs.pop(key)
 
         return inputs

--- a/optimum_benchmark/backends/openvino/backend.py
+++ b/optimum_benchmark/backends/openvino/backend.py
@@ -201,6 +201,10 @@ class OVBackend(Backend[OVConfig]):
             with Accelerator().split_between_processes(inputs=inputs, apply_padding=False) as process_inputs:
                 inputs = process_inputs
 
+        for key in list(inputs.keys()):
+            if key not in self.pretrained_model.input_names:
+                inputs.pop(key)
+
         return inputs
 
     def forward(self, inputs: Dict[str, Any], kwargs: Dict[str, Any]) -> OrderedDict:

--- a/optimum_benchmark/backends/peft_utils.py
+++ b/optimum_benchmark/backends/peft_utils.py
@@ -9,5 +9,8 @@ if is_peft_available():
 
 
 def apply_peft(model: PreTrainedModel, peft_type: str, peft_config: Dict[str, Any]) -> PreTrainedModel:
+    if not is_peft_available():
+        raise ImportError("peft is not available. Please, pip install peft.")
+
     peft_config = PEFT_TYPE_TO_CONFIG_MAPPING[peft_type](**peft_config)
     return get_peft_model(model=model, peft_config=peft_config)

--- a/optimum_benchmark/backends/timm_utils.py
+++ b/optimum_benchmark/backends/timm_utils.py
@@ -10,6 +10,9 @@ if is_timm_available():
 
 
 def get_timm_pretrained_config(model_name: str) -> PretrainedConfig:
+    if not is_timm_available():
+        raise ImportError("timm is not available. Please, pip install timm.")
+
     model_source, model_name = parse_model_name(model_name)
     if model_source == "hf-hub":
         # For model names specified in the form `hf-hub:path/architecture_name@revision`,
@@ -21,6 +24,9 @@ def get_timm_pretrained_config(model_name: str) -> PretrainedConfig:
 
 
 def extract_timm_shapes_from_config(config: PretrainedConfig) -> Dict[str, Any]:
+    if not is_timm_available():
+        raise ImportError("timm is not available. Please, pip install timm.")
+
     artifacts_dict = {}
 
     config_dict = {k: v for k, v in config.to_dict().items() if v is not None}
@@ -74,4 +80,7 @@ def extract_timm_shapes_from_config(config: PretrainedConfig) -> Dict[str, Any]:
 
 
 def get_timm_automodel_loader():
+    if not is_timm_available():
+        raise ImportError("timm is not available. Please, pip install timm.")
+
     return create_model

--- a/optimum_benchmark/benchmark/base.py
+++ b/optimum_benchmark/benchmark/base.py
@@ -36,8 +36,8 @@ class Benchmark(PushToHubMixin):
         elif not isinstance(self.report, BenchmarkReport):
             raise ValueError("report must be either a dict or a BenchmarkReport instance")
 
-    @classmethod
-    def launch(cls, config: BenchmarkConfig):
+    @staticmethod
+    def launch(config: BenchmarkConfig):
         """
         Runs an benchmark using specified launcher configuration/logic
         """
@@ -48,17 +48,18 @@ class Benchmark(PushToHubMixin):
         launcher: Launcher = launcher_factory(launcher_config)
 
         # Launch the benchmark using the launcher
-        report = launcher.launch(worker=cls.run, worker_args=[config])
+        report = launcher.launch(worker=Benchmark.run, worker_args=[config])
 
-        # Print the report
-        report.print()
-        # Log the report
-        report.log()
+        if config.log_report:
+            report.log()
+
+        if config.print_report:
+            report.print()
 
         return report
 
-    @classmethod
-    def run(cls, config: BenchmarkConfig):
+    @staticmethod
+    def run(config: BenchmarkConfig):
         """
         Runs a scenario using specified backend configuration/logic
         """

--- a/optimum_benchmark/benchmark/base.py
+++ b/optimum_benchmark/benchmark/base.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from logging import getLogger
 from typing import TYPE_CHECKING, Type
 
 from hydra.utils import get_class
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
     from ..backends.base import Backend
     from ..launchers.base import Launcher
     from ..scenarios.base import Scenario
+
+
+LOGGER = getLogger("benchmark")
 
 
 @dataclass
@@ -45,6 +49,11 @@ class Benchmark(PushToHubMixin):
 
         # Launch the benchmark using the launcher
         report = launcher.launch(worker=cls.run, worker_args=[config])
+
+        # Print the report
+        report.print()
+        # Log the report
+        report.log()
 
         return report
 

--- a/optimum_benchmark/benchmark/config.py
+++ b/optimum_benchmark/benchmark/config.py
@@ -20,6 +20,9 @@ class BenchmarkConfig(PushToHubMixin):
     # ENVIRONMENT CONFIGURATION
     environment: Dict[str, Any] = field(default_factory=lambda: {**get_system_info(), **get_hf_libs_info()})
 
+    print_report: bool = False
+    log_report: bool = True
+
     @classproperty
     def default_filename(cls) -> str:
         return "benchmark_config.json"

--- a/optimum_benchmark/benchmark/report.py
+++ b/optimum_benchmark/benchmark/report.py
@@ -113,7 +113,7 @@ class BenchmarkReport(PushToHubMixin):
         plain_text = ""
 
         for target in self.to_dict().keys():
-            plain_text += f"{target}:\n"
+            plain_text += f"+ {target}:\n"
             plain_text += getattr(self, target).to_plain_text()
 
         return plain_text

--- a/optimum_benchmark/benchmark/report.py
+++ b/optimum_benchmark/benchmark/report.py
@@ -51,26 +51,29 @@ class Measurements:
     def to_plain_text(self) -> str:
         plain_text = ""
 
-        for measurement_name in self.__annotations__.keys():
-            measurement = getattr(self, measurement_name)
+        for key in self.__annotations__.keys():
+            measurement = getattr(self, key)
             if measurement is not None:
+                plain_text += f"\t+ {key}:\n"
                 plain_text += measurement.to_plain_text()
 
         return plain_text
 
     def log(self):
-        for measurement_name in self.__annotations__.keys():
-            measurement = getattr(self, measurement_name)
-            if measurement is not None:
-                measurement.log()
+        for line in self.to_plain_text().split("\n"):
+            if line:
+                LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
+        i = 1
         markdown_text = ""
 
-        for measurement_name in self.__annotations__.keys():
-            measurement = getattr(self, measurement_name)
+        for key in self.__annotations__.keys():
+            measurement = getattr(self, key)
             if measurement is not None:
+                markdown_text += f"{i}. {key}:\n\n"
                 markdown_text += measurement.to_markdown_text()
+                i += 1
 
         return markdown_text
 
@@ -118,7 +121,7 @@ class BenchmarkReport(PushToHubMixin):
         markdown_text = ""
 
         for target in self.to_dict().keys():
-            markdown_text += f"# {target}\n" + getattr(self, target).to_markdown_text()
+            markdown_text += f"# {target}:\n" + getattr(self, target).to_markdown_text()
 
         return markdown_text
 

--- a/optimum_benchmark/benchmark/report.py
+++ b/optimum_benchmark/benchmark/report.py
@@ -50,13 +50,11 @@ class Measurements:
 
     def to_plain_text(self) -> str:
         plain_text = ""
-        i = 0
 
         for key in ["memory", "latency", "throughput", "energy", "efficiency"]:
             measurement = getattr(self, key)
             if measurement is not None:
-                i += 1
-                plain_text += f"\t+ {i}. {key}:\n"
+                plain_text += f"\t+ {key}:\n"
                 plain_text += measurement.to_plain_text()
 
         return plain_text
@@ -68,13 +66,11 @@ class Measurements:
 
     def to_markdown_text(self) -> str:
         markdown_text = ""
-        i = 0
 
         for key in ["memory", "latency", "throughput", "energy", "efficiency"]:
             measurement = getattr(self, key)
             if measurement is not None:
-                i += 1
-                markdown_text += f"{i}. {key}:\n\n"
+                markdown_text += f"## {key}:\n\n"
                 markdown_text += measurement.to_markdown_text()
 
         return markdown_text

--- a/optimum_benchmark/benchmark/report.py
+++ b/optimum_benchmark/benchmark/report.py
@@ -50,11 +50,13 @@ class Measurements:
 
     def to_plain_text(self) -> str:
         plain_text = ""
+        i = 0
 
-        for key in self.__annotations__.keys():
+        for key in ["memory", "latency", "throughput", "energy", "efficiency"]:
             measurement = getattr(self, key)
             if measurement is not None:
-                plain_text += f"\t+ {key}:\n"
+                i += 1
+                plain_text += f"\t+ {i}. {key}:\n"
                 plain_text += measurement.to_plain_text()
 
         return plain_text
@@ -65,17 +67,20 @@ class Measurements:
                 LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
-        i = 1
         markdown_text = ""
+        i = 0
 
-        for key in self.__annotations__.keys():
+        for key in ["memory", "latency", "throughput", "energy", "efficiency"]:
             measurement = getattr(self, key)
             if measurement is not None:
+                i += 1
                 markdown_text += f"{i}. {key}:\n\n"
                 markdown_text += measurement.to_markdown_text()
-                i += 1
 
         return markdown_text
+
+    def print(self):
+        CONSOLE.print(Markdown(self.to_markdown_text()))
 
 
 @dataclass
@@ -104,11 +109,16 @@ class BenchmarkReport(PushToHubMixin):
 
         return cls.from_dict(aggregated_measurements)
 
+    @classproperty
+    def default_filename(self) -> str:
+        return "benchmark_report.json"
+
     def to_plain_text(self) -> str:
         plain_text = ""
 
         for target in self.to_dict().keys():
-            plain_text += f"{target}:\n" + getattr(self, target).to_plain_text()
+            plain_text += f"{target}:\n"
+            plain_text += getattr(self, target).to_plain_text()
 
         return plain_text
 
@@ -121,13 +131,10 @@ class BenchmarkReport(PushToHubMixin):
         markdown_text = ""
 
         for target in self.to_dict().keys():
-            markdown_text += f"# {target}:\n" + getattr(self, target).to_markdown_text()
+            markdown_text += f"# {target}:\n\n"
+            markdown_text += getattr(self, target).to_markdown_text()
 
         return markdown_text
 
     def print(self):
         CONSOLE.print(Markdown(self.to_markdown_text()))
-
-    @classproperty
-    def default_filename(self) -> str:
-        return "benchmark_report.json"

--- a/optimum_benchmark/benchmark/report.py
+++ b/optimum_benchmark/benchmark/report.py
@@ -39,7 +39,37 @@ class BenchmarkMeasurements:
         energy = Energy.aggregate([m.energy for m in measurements]) if m0.energy is not None else None
         efficiency = Efficiency.aggregate([m.efficiency for m in measurements]) if m0.efficiency is not None else None
 
-        return BenchmarkMeasurements(memory, latency, throughput, energy, efficiency)
+        return BenchmarkMeasurements(
+            memory=memory, latency=latency, throughput=throughput, energy=energy, efficiency=efficiency
+        )
+
+    def log(self, prefix: str = ""):
+        if self.memory is not None:
+            self.memory.log(prefix=prefix)
+        if self.latency is not None:
+            self.latency.log(prefix=prefix)
+        if self.throughput is not None:
+            self.throughput.log(prefix=prefix)
+        if self.energy is not None:
+            self.energy.log(prefix=prefix)
+        if self.efficiency is not None:
+            self.efficiency.log(prefix=prefix)
+
+    def markdown(self, prefix: str = "") -> str:
+        markdown = ""
+
+        if self.memory is not None:
+            markdown += self.memory.markdown(prefix=prefix)
+        if self.latency is not None:
+            markdown += self.latency.markdown(prefix=prefix)
+        if self.throughput is not None:
+            markdown += self.throughput.markdown(prefix=prefix)
+        if self.energy is not None:
+            markdown += self.energy.markdown(prefix=prefix)
+        if self.efficiency is not None:
+            markdown += self.efficiency.markdown(prefix=prefix)
+
+        return markdown
 
 
 @dataclass
@@ -59,50 +89,6 @@ class BenchmarkReport(PushToHubMixin):
             elif isinstance(getattr(self, target), dict):
                 setattr(self, target, BenchmarkMeasurements(**getattr(self, target)))
 
-    def log_memory(self):
-        for target in self.to_dict().keys():
-            measurements: BenchmarkMeasurements = getattr(self, target)
-            if measurements.memory is not None:
-                measurements.memory.log(prefix=target)
-
-    def log_latency(self):
-        for target in self.to_dict().keys():
-            measurements: BenchmarkMeasurements = getattr(self, target)
-            if measurements.latency is not None:
-                measurements.latency.log(prefix=target)
-
-    def log_throughput(self):
-        for target in self.to_dict().keys():
-            measurements: BenchmarkMeasurements = getattr(self, target)
-            if measurements.throughput is not None:
-                measurements.throughput.log(prefix=target)
-
-    def log_energy(self):
-        for target in self.to_dict().keys():
-            measurements: BenchmarkMeasurements = getattr(self, target)
-            if measurements.energy is not None:
-                measurements.energy.log(prefix=target)
-
-    def log_efficiency(self):
-        for target in self.to_dict().keys():
-            measurements: BenchmarkMeasurements = getattr(self, target)
-            if measurements.efficiency is not None:
-                measurements.efficiency.log(prefix=target)
-
-    def log(self):
-        for target in self.to_dict().keys():
-            measurements: BenchmarkMeasurements = getattr(self, target)
-            if measurements.memory is not None:
-                measurements.memory.log(prefix=target)
-            if measurements.latency is not None:
-                measurements.latency.log(prefix=target)
-            if measurements.throughput is not None:
-                measurements.throughput.log(prefix=target)
-            if measurements.energy is not None:
-                measurements.energy.log(prefix=target)
-            if measurements.efficiency is not None:
-                measurements.efficiency.log(prefix=target)
-
     @classmethod
     def aggregate(cls, reports: List["BenchmarkReport"]) -> "BenchmarkReport":
         aggregated_measurements = {}
@@ -111,6 +97,20 @@ class BenchmarkReport(PushToHubMixin):
             aggregated_measurements[target] = BenchmarkMeasurements.aggregate(measurements)
 
         return cls.from_dict(aggregated_measurements)
+
+    def log(self):
+        for target in self.to_dict().keys():
+            measurements: BenchmarkMeasurements = getattr(self, target)
+            measurements.log(prefix=target)
+
+    def markdown(self):
+        markdown = ""
+
+        for target in self.to_dict().keys():
+            measurements: BenchmarkMeasurements = getattr(self, target)
+            markdown += measurements.markdown(prefix=target)
+
+        return markdown
 
     @classproperty
     def default_filename(self) -> str:

--- a/optimum_benchmark/cli.py
+++ b/optimum_benchmark/cli.py
@@ -78,7 +78,9 @@ def main(config: DictConfig) -> None:
     benchmark_config.save_json("benchmark_config.json")
 
     benchmark_report = Benchmark.launch(benchmark_config)
+    benchmark_report.save_markdown("benchmark_report.md")
     benchmark_report.save_json("benchmark_report.json")
+    benchmark_report.save_text("benchmark_report.txt")
 
     benchmark = Benchmark(config=benchmark_config, report=benchmark_report)
     benchmark.save_json("benchmark.json")

--- a/optimum_benchmark/launchers/inline/launcher.py
+++ b/optimum_benchmark/launchers/inline/launcher.py
@@ -15,6 +15,5 @@ class InlineLauncher(Launcher[InlineConfig]):
         self.logger.warning("The inline launcher is only recommended for debugging purposes and not for benchmarking")
 
         report = worker(*worker_args)
-        report.log()
 
         return report

--- a/optimum_benchmark/launchers/inline/launcher.py
+++ b/optimum_benchmark/launchers/inline/launcher.py
@@ -13,5 +13,8 @@ class InlineLauncher(Launcher[InlineConfig]):
 
     def launch(self, worker: Callable[..., BenchmarkReport], worker_args: List[Any]) -> BenchmarkReport:
         self.logger.warning("The inline launcher is only recommended for debugging purposes and not for benchmarking")
+
         report = worker(*worker_args)
+        report.log()
+
         return report

--- a/optimum_benchmark/launchers/process/launcher.py
+++ b/optimum_benchmark/launchers/process/launcher.py
@@ -70,7 +70,6 @@ class ProcessLauncher(Launcher[ProcessConfig]):
         elif "report" in response:
             self.logger.info("\t+ Received report from isolated process")
             report = BenchmarkReport.from_dict(response["report"])
-            report.log()
         else:
             raise RuntimeError(f"Received an unexpected response from isolated process: {response}")
 

--- a/optimum_benchmark/launchers/torchrun/launcher.py
+++ b/optimum_benchmark/launchers/torchrun/launcher.py
@@ -102,8 +102,6 @@ class TorchrunLauncher(Launcher[TorchrunConfig]):
 
         self.logger.info("\t+ Aggregating reports from all rank processes")
         report = BenchmarkReport.aggregate(reports)
-        report.log()
-
         return report
 
 

--- a/optimum_benchmark/scenarios/inference/scenario.py
+++ b/optimum_benchmark/scenarios/inference/scenario.py
@@ -151,12 +151,12 @@ class InferenceScenario(Scenario[InferenceConfig]):
     def run_model_loading_tracking(self, backend: Backend[BackendConfigT]):
         self.logger.info("\t+ Running model loading tracking")
 
-        if self.config.latency:
-            latency_tracker = LatencyTracker(backend=backend.config.name, device=backend.config.device)
         if self.config.memory:
             memory_tracker = MemoryTracker(
                 backend=backend.config.name, device=backend.config.device, device_ids=backend.config.device_ids
             )
+        if self.config.latency:
+            latency_tracker = LatencyTracker(backend=backend.config.name, device=backend.config.device)
         if self.config.energy:
             energy_tracker = EnergyTracker(
                 backend=backend.config.name, device=backend.config.device, device_ids=backend.config.device_ids
@@ -172,10 +172,10 @@ class InferenceScenario(Scenario[InferenceConfig]):
 
             backend.load()
 
-        if self.config.latency:
-            self.report.load.latency = latency_tracker.get_latency()
         if self.config.memory:
             self.report.load.memory = memory_tracker.get_max_memory()
+        if self.config.latency:
+            self.report.load.latency = latency_tracker.get_latency()
         if self.config.energy:
             self.report.load.energy = energy_tracker.get_energy()
 

--- a/optimum_benchmark/scenarios/inference/scenario.py
+++ b/optimum_benchmark/scenarios/inference/scenario.py
@@ -168,7 +168,7 @@ class InferenceScenario(Scenario[InferenceConfig]):
             if self.config.latency:
                 context_stack.enter_context(latency_tracker.track())
             if self.config.energy:
-                context_stack.enter_context(energy_tracker.track(task="load"))
+                context_stack.enter_context(energy_tracker.track(file_prefix="load"))
 
             backend.load()
 

--- a/optimum_benchmark/scenarios/inference/scenario.py
+++ b/optimum_benchmark/scenarios/inference/scenario.py
@@ -163,12 +163,12 @@ class InferenceScenario(Scenario[InferenceConfig]):
             )
 
         with ExitStack() as context_stack:
-            if self.config.latency:
-                context_stack.enter_context(latency_tracker.track())
             if self.config.memory:
                 context_stack.enter_context(memory_tracker.track())
+            if self.config.latency:
+                context_stack.enter_context(latency_tracker.track())
             if self.config.energy:
-                context_stack.enter_context(energy_tracker.track())
+                context_stack.enter_context(energy_tracker.track(task="load"))
 
             backend.load()
 

--- a/optimum_benchmark/scenarios/training/scenario.py
+++ b/optimum_benchmark/scenarios/training/scenario.py
@@ -48,7 +48,9 @@ class TrainingScenario(Scenario[TrainingConfig]):
                 )
                 context_stack.enter_context(memory_tracker.track())
             if self.config.energy:
-                energy_tracker = EnergyTracker(device=backend.config.device, device_ids=backend.config.device_ids)
+                energy_tracker = EnergyTracker(
+                    device=backend.config.device, backend=backend.config.name, device_ids=backend.config.device_ids
+                )
                 context_stack.enter_context(energy_tracker.track(file_prefix="train"))
 
             backend.train(

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -117,7 +117,8 @@ class Efficiency:
         return Efficiency(value=volume / energy.total if energy.total > 0 else 0, unit=unit)
 
     def log(self, prefix: str = ""):
-        LOGGER.info(f"\t\t+ {prefix} efficiency: {self.value:f} ({self.unit})")
+        LOGGER.info(f"\t\t+ {prefix} efficiency")
+        LOGGER.info(f"\t\t\t- efficiency: {self.value:f} ({self.unit})")
 
     def markdown(self, prefix: str = "") -> str:
         markdown = ""
@@ -142,7 +143,7 @@ class EnergyTracker:
         self.is_gpu = self.device == "cuda"
         self.is_pytorch_cuda = (self.backend, self.device) == ("pytorch", "cuda")
 
-        LOGGER.info("\t+ Tracking CPU and RAM energy")
+        LOGGER.info("\t\t+ Tracking RAM and CPU energy consumption")
 
         if self.is_gpu:
             if isinstance(self.device_ids, str):
@@ -156,7 +157,7 @@ class EnergyTracker:
             else:
                 raise ValueError("GPU device IDs must be a string, an integer, or a list of integers")
 
-            LOGGER.info(f"\t+ Tracking GPU energy on devices {self.device_ids}")
+            LOGGER.info(f"\t\t+ Tracking GPU energy consumption on devices {self.device_ids}")
 
         if not is_codecarbon_available():
             raise ValueError(

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -48,12 +48,27 @@ class Energy:
 
         return Energy(cpu=cpu, gpu=gpu, ram=ram, total=total, unit=ENERGY_UNIT)
 
-    def log(self, prefix: str = "forward"):
-        LOGGER.info(f"\t\t+ {prefix} energy consumption:")
-        LOGGER.info(f"\t\t\t+ CPU: {self.cpu:f} ({self.unit})")
-        LOGGER.info(f"\t\t\t+ GPU: {self.gpu:f} ({self.unit})")
-        LOGGER.info(f"\t\t\t+ RAM: {self.ram:f} ({self.unit})")
-        LOGGER.info(f"\t\t\t+ total: {self.total:f} ({self.unit})")
+    def log(self, prefix: str = ""):
+        LOGGER.info(f"\t\t+ {prefix} energy:")
+        LOGGER.info(f"\t\t\t- cpu: {self.cpu:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- gpu: {self.gpu:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- ram: {self.ram:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- total: {self.total:f} ({self.unit})")
+
+    def markdown(self, prefix: str = "") -> str:
+        markdown = ""
+        markdown += "| ---------------------------------------- |\n"
+        markdown += "| {prefix} energy                          |\n"
+        markdown += "| ---------------------------------------- |\n"
+        markdown += "| metric    | value (unit)                 |\n"
+        markdown += "| :-------- | ---------------------------: |\n"
+        markdown += "| cpu       | {self.cpu:f} ({self.unit})   |\n"
+        markdown += "| gpu       | {self.gpu:f} ({self.unit})   |\n"
+        markdown += "| ram       | {self.ram:f} ({self.unit})   |\n"
+        markdown += "| total     | {self.total:f} ({self.unit}) |\n"
+        markdown += "| ---------------------------------------- |\n"
+
+        return markdown.format(prefix=prefix, **asdict(self))
 
     def __sub__(self, other: "Energy") -> "Energy":
         """Enables subtraction of two Energy instances using the '-' operator."""
@@ -102,7 +117,20 @@ class Efficiency:
         return Efficiency(value=volume / energy.total if energy.total > 0 else 0, unit=unit)
 
     def log(self, prefix: str = ""):
-        LOGGER.info(f"\t\t+ {prefix} energy efficiency: {self.value:f} ({self.unit})")
+        LOGGER.info(f"\t\t+ {prefix} efficiency: {self.value:f} ({self.unit})")
+
+    def markdown(self, prefix: str = "") -> str:
+        markdown = ""
+
+        markdown += "| ------------------------------- |\n"
+        markdown += "| {prefix} efficiency             |\n"
+        markdown += "| ------------------------------- |\n"
+        markdown += "| metric     | value (unit)       |\n"
+        markdown += "| :--------- | -----------------: |\n"
+        markdown += "| efficiency | {value:f} ({unit}) |\n"
+        markdown += "| ------------------------------- |\n"
+
+        return markdown.format(prefix=prefix, **asdict(self))
 
 
 class EnergyTracker:

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -75,7 +75,7 @@ class Energy:
         return Energy(cpu=cpu, gpu=gpu, ram=ram, total=total, unit=ENERGY_UNIT)
 
     def to_plain_text(self) -> str:
-        plain_text = "\t+ energy:\n"
+        plain_text = ""
         plain_text += "\t\t+ cpu: {cpu:f} ({unit})\n"
         plain_text += "\t\t+ gpu: {gpu:f} ({unit})\n"
         plain_text += "\t\t+ ram: {ram:f} ({unit})\n"
@@ -88,7 +88,7 @@ class Energy:
                 LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
-        markdown_text = "## energy\n"
+        markdown_text = ""
         markdown_text += "| metric     |     value |   unit |\n"
         markdown_text += "| :--------- | --------: | -----: |\n"
         markdown_text += "| cpu        |   {cpu:f} | {unit} |\n"
@@ -124,7 +124,7 @@ class Efficiency:
         return Efficiency(value=volume / energy.total if energy.total > 0 else 0, unit=unit)
 
     def to_plain_text(self) -> str:
-        plain_text = "\t+ efficiency:\n"
+        plain_text = ""
         plain_text += "\t\t+ efficiency: {value:f} ({unit})\n"
         return plain_text.format(**asdict(self))
 
@@ -134,7 +134,7 @@ class Efficiency:
                 LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
-        markdown_text = "## efficiency\n"
+        markdown_text = ""
         markdown_text += "| metric     |     value |   unit |\n"
         markdown_text += "| :--------- | --------: | -----: |\n"
         markdown_text += "| efficiency | {value:f} | {unit} |\n"

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -125,7 +125,7 @@ class Efficiency:
 
     def to_plain_text(self) -> str:
         plain_text = "\t+ efficiency:\n"
-        plain_text += "\t\t+ efficiency: {self.value:f} ({self.unit})\n"
+        plain_text += "\t\t+ efficiency: {value:f} ({unit})\n"
         return plain_text.format(**asdict(self))
 
     def log(self):

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -117,7 +117,7 @@ class Efficiency:
         return Efficiency(value=volume / energy.total if energy.total > 0 else 0, unit=unit)
 
     def log(self, prefix: str = ""):
-        LOGGER.info(f"\t\t+ {prefix} efficiency")
+        LOGGER.info(f"\t\t+ {prefix} efficiency:")
         LOGGER.info(f"\t\t\t- efficiency: {self.value:f} ({self.unit})")
 
     def markdown(self, prefix: str = "") -> str:

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -22,7 +22,8 @@ LOGGER = getLogger("energy")
 
 POWER_UNIT = "W"
 ENERGY_UNIT = "kWh"
-POWER_CONSUMPTION_SAMPLING_RATE = 1
+POWER_CONSUMPTION_SAMPLING_RATE = 1  # in seconds
+
 Energy_Unit_Literal = Literal["kWh"]
 Efficiency_Unit_Literal = Literal["samples/kWh", "tokens/kWh", "images/kWh"]
 

--- a/optimum_benchmark/trackers/energy.py
+++ b/optimum_benchmark/trackers/energy.py
@@ -181,11 +181,11 @@ class EnergyTracker:
                 measure_power_secs=POWER_CONSUMPTION_SAMPLING_RATE,
             )
         except Exception:
-            LOGGER.warning("\t+ Falling back to Offline Emissions Tracker")
+            LOGGER.warning("\t\t+ Falling back to Offline Emissions Tracker")
 
             if os.environ.get("COUNTRY_ISO_CODE", None) is None:
                 LOGGER.warning(
-                    "\t+ Offline Emissions Tracker requires COUNTRY_ISO_CODE to be set. "
+                    "\t\t+ Offline Emissions Tracker requires COUNTRY_ISO_CODE to be set. "
                     "We will set it to USA but the carbon footprint might be inaccurate."
                 )
 
@@ -225,7 +225,7 @@ class EnergyTracker:
         emission_data: EmissionsData = self.emission_tracker.stop_task()
 
         with open(f"{file_prefix}_codecarbon.json", "w") as f:
-            LOGGER.info(f"\t+ Saving codecarbon emission data to {file_prefix}_codecarbon.json")
+            LOGGER.info(f"\t\t+ Saving codecarbon emission data to {file_prefix}_codecarbon.json")
             dump(asdict(emission_data), f, indent=4)
 
         self.total_energy = emission_data.energy_consumed

--- a/optimum_benchmark/trackers/latency.py
+++ b/optimum_benchmark/trackers/latency.py
@@ -14,6 +14,7 @@ CONSOLE = Console()
 LOGGER = getLogger("latency")
 
 LATENCY_UNIT = "s"
+
 Latency_Unit_Literal = Literal["s"]
 Throughput_Unit_Literal = Literal["samples/s", "tokens/s", "images/s", "steps/s"]
 
@@ -110,6 +111,9 @@ class Latency:
         markdown_text += "| stdev  |    {stdev:f} | {unit} |\n"
         markdown_text += "| stdev_ | {stdev_:.2f} |      % |\n"
         return markdown_text.format(**asdict(self))
+
+    def print(self):
+        CONSOLE.print(Markdown(self.to_markdown_text()))
 
 
 @dataclass

--- a/optimum_benchmark/trackers/latency.py
+++ b/optimum_benchmark/trackers/latency.py
@@ -1,6 +1,6 @@
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from logging import getLogger
 from typing import List, Literal, Optional, Union
 
@@ -74,16 +74,40 @@ class Latency:
         )
 
     def log(self, prefix: str = ""):
-        stdev_percentage = 100 * self.stdev / self.mean if self.mean > 0 else 0
         LOGGER.info(f"\t\t+ {prefix} latency:")
         LOGGER.info(f"\t\t\t- count: {self.count}")
-        LOGGER.info(f"\t\t\t- total: {self.total:f} {self.unit}")
-        LOGGER.info(f"\t\t\t- mean: {self.mean:f} {self.unit}")
-        LOGGER.info(f"\t\t\t- stdev: {self.stdev:f} {self.unit} ({stdev_percentage:.2f}%)")
-        LOGGER.info(f"\t\t\t- p50: {self.p50:f} {self.unit}")
-        LOGGER.info(f"\t\t\t- p90: {self.p90:f} {self.unit}")
-        LOGGER.info(f"\t\t\t- p95: {self.p95:f} {self.unit}")
-        LOGGER.info(f"\t\t\t- p99: {self.p99:f} {self.unit}")
+        LOGGER.info(f"\t\t\t- total: {self.total:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- mean: {self.mean:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- p50: {self.p50:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- p90: {self.p90:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- p95: {self.p95:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- p99: {self.p99:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- stdev: {self.stdev:f} ({self.unit})")
+        LOGGER.info(f"\t\t\t- stdev_: {self.stdev_percentage:.2f} (%)")
+
+    def markdown(self, prefix: str = "") -> str:
+        markdown = ""
+        markdown += "| -------------------------------------- |\n"
+        markdown += "| {prefix} latency                       |\n"
+        markdown += "| -------------------------------------- |\n"
+        markdown += "| metric    | value (unit)               |\n"
+        markdown += "| :-------- | -------------------------: |\n"
+        markdown += "| count     | {count}                    |\n"
+        markdown += "| total     | {total:f} ({unit})         |\n"
+        markdown += "| mean      | {mean:f} ({unit})          |\n"
+        markdown += "| p50       | {p50:f} ({unit})           |\n"
+        markdown += "| p90       | {p90:f} ({unit})           |\n"
+        markdown += "| p95       | {p95:f} ({unit})           |\n"
+        markdown += "| p99       | {p99:f} ({unit})           |\n"
+        markdown += "| stdev     | {stdev:f} ({unit})         |\n"
+        markdown += "| stdev_    | {stdev_percentage:.2f} (%) |\n"
+        markdown += "| -------------------------------------- |\n"
+
+        return markdown.format(prefix=prefix, stdev_percentage=self.stdev_percentage, **asdict(self))
+
+    @property
+    def stdev_percentage(self) -> float:
+        return 100 * self.stdev / self.mean if self.mean > 0 else 0
 
 
 @dataclass
@@ -109,8 +133,20 @@ class Throughput:
         value = volume / latency.mean if latency.mean > 0 else 0
         return Throughput(value=value, unit=unit)
 
-    def log(self, prefix: str = "method"):
+    def log(self, prefix: str = ""):
         LOGGER.info(f"\t\t+ {prefix} throughput: {self.value:f} {self.unit}")
+
+    def markdown(self, prefix: str = "") -> str:
+        markdown = ""
+        markdown += "| ------------------------------- |\n"
+        markdown += "| {prefix} throughput             |\n"
+        markdown += "| ------------------------------- |\n"
+        markdown += "| metric     | value (unit)       |\n"
+        markdown += "| :--------- | -----------------: |\n"
+        markdown += "| throughput | {value:f} ({unit}) |\n"
+        markdown += "| ------------------------------- |\n"
+
+        return markdown.format(prefix=prefix, **asdict(self))
 
 
 class LatencyTracker:

--- a/optimum_benchmark/trackers/latency.py
+++ b/optimum_benchmark/trackers/latency.py
@@ -134,7 +134,7 @@ class Throughput:
         return Throughput(value=value, unit=unit)
 
     def log(self, prefix: str = ""):
-        LOGGER.info(f"\t\t+ {prefix} throughput")
+        LOGGER.info(f"\t\t+ {prefix} throughput:")
         LOGGER.info(f"\t\t\t- throughput: {self.value:f} ({self.unit})")
 
     def markdown(self, prefix: str = "") -> str:

--- a/optimum_benchmark/trackers/latency.py
+++ b/optimum_benchmark/trackers/latency.py
@@ -79,7 +79,7 @@ class Latency:
         )
 
     def to_plain_text(self) -> str:
-        plain_text = "\t+ latency:\n"
+        plain_text = ""
         plain_text += "\t\t+ count: {count}\n"
         plain_text += "\t\t+ total: {total:.6f} ({unit})\n"
         plain_text += "\t\t+ mean: {mean:.6f} ({unit})\n"
@@ -97,7 +97,7 @@ class Latency:
                 LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
-        markdown_text = "## latency\n"
+        markdown_text = ""
         markdown_text += "| metric | value        | unit   |\n"
         markdown_text += "| :----- | -----------: |------: |\n"
         markdown_text += "| count  |      {count} |      - |\n"
@@ -136,7 +136,7 @@ class Throughput:
         return Throughput(value=value, unit=unit)
 
     def to_plain_text(self) -> str:
-        plain_text = "\t+ throughput:\n"
+        plain_text = ""
         plain_text += "\t\t+ throughput: {value:.2f} ({unit})\n"
         return plain_text.format(**asdict(self))
 
@@ -146,7 +146,7 @@ class Throughput:
                 LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
-        markdown_text = "## throughput\n"
+        markdown_text = ""
         markdown_text += "| metric     |     value   |   unit |\n"
         markdown_text += "| :--------- | --------:   | -----: |\n"
         markdown_text += "| throughput | {value:.2f} | {unit} |\n"

--- a/optimum_benchmark/trackers/latency.py
+++ b/optimum_benchmark/trackers/latency.py
@@ -134,7 +134,8 @@ class Throughput:
         return Throughput(value=value, unit=unit)
 
     def log(self, prefix: str = ""):
-        LOGGER.info(f"\t\t+ {prefix} throughput: {self.value:f} {self.unit}")
+        LOGGER.info(f"\t\t+ {prefix} throughput")
+        LOGGER.info(f"\t\t\t- throughput: {self.value:f} ({self.unit})")
 
     def markdown(self, prefix: str = "") -> str:
         markdown = ""
@@ -157,9 +158,9 @@ class LatencyTracker:
         self.is_pytorch_cuda = (self.backend, self.device) == ("pytorch", "cuda")
 
         if self.is_pytorch_cuda:
-            LOGGER.info("\t+ Tracking latency using Pytorch CUDA events")
+            LOGGER.info("\t\t+ Tracking latency using Pytorch CUDA events")
         else:
-            LOGGER.info("\t+ Tracking latency using CPU performance counter")
+            LOGGER.info("\t\t+ Tracking latency using CPU performance counter")
 
         self.start_time: Optional[float] = None
         self.start_events: List[Union[float, torch.cuda.Event]] = []
@@ -235,9 +236,9 @@ class StepLatencyTrainerCallback(TrainerCallback):
         self.is_pytorch_cuda = (self.backend, self.device) == ("pytorch", "cuda")
 
         if self.is_pytorch_cuda:
-            LOGGER.info("\t+ Tracking latency using Pytorch CUDA events")
+            LOGGER.info("\t\t+ Tracking latency using Pytorch CUDA events")
         else:
-            LOGGER.info("\t+ Tracking latency using CPU performance counter")
+            LOGGER.info("\t\t+ Tracking latency using CPU performance counter")
 
         self.start_events: List[Union[float, torch.cuda.Event]] = []
         self.end_events: List[Union[float, torch.cuda.Event]] = []
@@ -285,9 +286,9 @@ class PerTokenLatencyLogitsProcessor(LogitsProcessor):
         self.is_pytorch_cuda = (self.backend, self.device) == ("pytorch", "cuda")
 
         if self.is_pytorch_cuda:
-            LOGGER.info("\t+ Tracking latency using Pytorch CUDA events")
+            LOGGER.info("\t\t+ Tracking latency using Pytorch CUDA events")
         else:
-            LOGGER.info("\t+ Tracking latency using CPU performance counter")
+            LOGGER.info("\t\t+ Tracking latency using CPU performance counter")
 
         self.start_time: Optional[float] = None
         self.prefilled: Optional[bool] = None

--- a/optimum_benchmark/trackers/memory.py
+++ b/optimum_benchmark/trackers/memory.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from logging import getLogger
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
@@ -89,6 +89,27 @@ class Memory:
             LOGGER.info(f"\t\t\t- max reserved memory: {self.max_reserved:f} ({self.unit})")
         if self.max_allocated is not None:
             LOGGER.info(f"\t\t\t- max allocated memory: {self.max_allocated:f} ({self.unit})")
+
+    def markdown(self, prefix: str = "") -> str:
+        markdown = ""
+        markdown += "| ----------------------------------------------------- |\n"
+        markdown += "| {prefix} memory:                                      |\n"
+        markdown += "| ----------------------------------------------------- |\n"
+        markdown += "| metric | value (unit)                                 |\n"
+        markdown += "| ------ | -------------------------------------------- |\n"
+        if self.max_ram is not None:
+            markdown += "| max RAM | {max_ram:f} ({unit})                    |\n"
+        if self.max_global_vram is not None:
+            markdown += "| max global VRAM | {max_global_vram:f} ({unit})    |\n"
+        if self.max_process_vram is not None:
+            markdown += "| max process VRAM | {max_process_vram:f} ({unit})  |\n"
+        if self.max_reserved is not None:
+            markdown += "| max reserved memory | {max_reserved:f} ({unit})   |\n"
+        if self.max_allocated is not None:
+            markdown += "| max allocated memory | {max_allocated:f} ({unit}) |\n"
+        markdown += "| ----------------------------------------------------- |\n"
+
+        return markdown.format(prefix=prefix, **asdict(self))
 
 
 class MemoryTracker:

--- a/optimum_benchmark/trackers/memory.py
+++ b/optimum_benchmark/trackers/memory.py
@@ -82,7 +82,7 @@ class Memory:
         )
 
     def to_plain_text(self) -> str:
-        plain_text = "\t +memory:\n"
+        plain_text = ""
         if self.max_ram is not None:
             plain_text += "\t\t+ max_ram: {max_ram:.2f} ({unit})\n"
         if self.max_global_vram is not None:
@@ -101,7 +101,7 @@ class Memory:
                 LOGGER.info(line)
 
     def to_markdown_text(self) -> str:
-        markdown_text = "## memory\n"
+        markdown_text = ""
         markdown_text += "| metric | value | unit |\n"
         markdown_text += "| ------ | ----: | ---: |\n"
         if self.max_ram is not None:

--- a/optimum_benchmark/trackers/memory.py
+++ b/optimum_benchmark/trackers/memory.py
@@ -122,7 +122,7 @@ class MemoryTracker:
         self.is_gpu = device == "cuda"
         self.is_pytorch_cuda = (self.backend, self.device) == ("pytorch", "cuda")
 
-        LOGGER.info(f"\t+ Tracking RAM memory of process [{self.monitored_pid}]")
+        LOGGER.info(f"\t\t+ Tracking RAM memory of process {self.monitored_pid}")
 
         if self.is_gpu:
             if isinstance(self.device_ids, str):
@@ -136,7 +136,7 @@ class MemoryTracker:
             else:
                 raise ValueError("GPU device IDs must be a string, an integer, or a list of integers")
 
-            LOGGER.info(f"\t+ Tracking GPU memory of devices {self.device_ids}")
+            LOGGER.info(f"\t\t+ Tracking GPU memory of devices {self.device_ids}")
 
         if self.is_pytorch_cuda:
             self.num_pytorch_devices = torch.cuda.device_count()
@@ -146,7 +146,7 @@ class MemoryTracker:
                     f"Got {len(self.device_ids)} and {self.num_pytorch_devices} respectively."
                 )
 
-            LOGGER.info(f"\t+ Tracking Allocated/Reserved memory of {self.num_pytorch_devices} Pytorch CUDA devices")
+            LOGGER.info(f"\t\t+ Tracking Allocated/Reserved memory of {self.num_pytorch_devices} Pytorch CUDA devices")
 
         self.max_ram_memory = None
         self.max_global_vram_memory = None

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ INSTALL_REQUIRES = [
     "transformers",
     "accelerate",
     "datasets",
-    "optimum",
     # Hydra
     "hydra-core",
     "omegaconf",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ INSTALL_REQUIRES = [
     "transformers",
     "accelerate",
     "datasets",
+    "optimum",
     # Hydra
     "hydra-core",
     "omegaconf",
@@ -29,6 +30,7 @@ INSTALL_REQUIRES = [
     "flatten_dict",
     "colorlog",
     "pandas",
+    "rich",
 ]
 
 try:

--- a/tests/configs/_base_.yaml
+++ b/tests/configs/_base_.yaml
@@ -5,6 +5,9 @@ defaults:
   - scenario: inference # default scenario
   - _self_
 
+print_report: true
+log_report: true
+
 # hydra/cli specific settings
 hydra:
   run:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,6 +102,8 @@ def test_api_launch(device, scenario, library, task, model):
         scenario=scenario_config,
         launcher=launcher_config,
         backend=backend_config,
+        print_report=True,
+        log_report=True,
     )
     benchmark_report = Benchmark.launch(benchmark_config)
 
@@ -123,6 +125,8 @@ def test_api_push_to_hub_mixin():
         scenario=scenario_config,
         launcher=launcher_config,
         backend=backend_config,
+        print_report=True,
+        log_report=True,
     )
     benchmark_report = Benchmark.launch(benchmark_config)
     benchmark = Benchmark(config=benchmark_config, report=benchmark_report)


### PR DESCRIPTION
Making reporting much better with grouped benchmark report logging and printing.
The benchmark report class `BenchmarkReport` can now be viewed with `.log()` or `.print()`. It can also be transformed entirely into text, through `to_plain_text` and `to_markdown_text`.
The benchmark config class `BenchmarkConfig` get two additional arguments `print_report` (default false) and `log_report` (default true) to control this behavior.

new report logging:
```
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - + load:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ memory:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ max_ram: 949.44 (MB)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ latency:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ count: 1
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ total: 1.244811 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ mean: 1.244811 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p50: 1.244811 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p90: 1.244811 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p95: 1.244811 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p99: 1.244811 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ stdev: 0.000000 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ stdev_: 0.00 (%)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - + forward:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ memory:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ max_ram: 960.98 (MB)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ latency:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ count: 22
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ total: 1.023933 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ mean: 0.046542 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p50: 0.046848 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p90: 0.049224 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p95: 0.049346 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ p99: 0.049694 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ stdev: 0.002056 (s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ stdev_: 4.42 (%)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ throughput:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ throughput: 21.49 (samples/s)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ energy:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ cpu: 0.000002 (kWh)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ gpu: 0.000000 (kWh)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ ram: 0.000000 (kWh)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ total: 0.000002 (kWh)
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 	+ efficiency:
[PYTEST-PROCESS][2024-10-03 11:52:30][benchmark][INFO] - 		+ efficiency: 574475.856681 (samples/kWh)
```

new report printing:
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                                    load:                                     ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                    memory:                                     
                           
  metric     value   unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━ 
  max_ram   949.44     MB  
                           
                                    latency:                                    
                            
  metric      value   unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  count           1      -  
  total    1.244811      s  
  mean     1.244811      s  
  p50      1.244811      s  
  p90      1.244811      s  
  p95      1.244811      s  
  p99      1.244811      s  
  stdev    0.000000      s  
  stdev_       0.00      %  
                            
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                                   forward:                                   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                    memory:                                     
                           
  metric     value   unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━ 
  max_ram   960.98     MB  
                           
                                    latency:                                    
                            
  metric      value   unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  count          22      -  
  total    1.023933      s  
  mean     0.046542      s  
  p50      0.046848      s  
  p90      0.049224      s  
  p95      0.049346      s  
  p99      0.049694      s  
  stdev    0.002056      s  
  stdev_       4.42      %  
                            
                                  throughput:                                   
                                  
  metric       value        unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  throughput   21.49   samples/s  
                                  
                                    energy:                                     
                            
  metric      value   unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  cpu      0.000002    kWh  
  gpu      0.000000    kWh  
  ram      0.000000    kWh  
  total    0.000002    kWh  
                            
                                  efficiency:                                   
                                            
  metric               value          unit  
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  efficiency   574475.856681   samples/kWh  
```