### PR TITLE
[DRAFT] Set vllm version limit to avoid upstream API incompatibility

### DIFF
--- a/optimum_benchmark/backends/vllm/backend.py
+++ b/optimum_benchmark/backends/vllm/backend.py
@@ -117,35 +117,31 @@ class VLLMBackend(Backend[VLLMConfig]):
             self.pretrained_model.add_request(
                 inputs=prompt,
                 request_id=str(i),
-                params=SamplingParams(
-                    ignore_eos=True,
-                    detokenize=True,
-                    seed=self.config.seed,
-                    n=kwargs.get("num_return_sequences"),
-                    max_tokens=kwargs.get("max_new_tokens"),
-                    min_tokens=kwargs.get("min_new_tokens"),
-                    use_beam_search=kwargs.get("num_beams") > 1,
-                    logits_processors=kwargs.get("logits_processors", None),
-                ),
+                params=self.get_sampling_params(kwargs),
             )
 
         while self.pretrained_model.has_unfinished_requests():
             self.pretrained_model.step()
 
+    def get_sampling_params(self, kwargs: Dict[str, Any]) -> SamplingParams:
+        params = SamplingParams(
+            ignore_eos=True,
+            detokenize=True,
+            seed=self.config.seed,
+            n=kwargs.get("num_return_sequences"),
+            max_tokens=kwargs.get("max_new_tokens"),
+            min_tokens=kwargs.get("min_new_tokens"),
+            logits_processors=kwargs.get("logits_processors", None),
+        )
+        if kwargs.get("num_beams") > 1:
+            params.logprobs = 2 * kwargs.get("num_beams")
+        return params
+
     async def single_online_engine_generate(self, prompt: str, request_id: str, kwargs: Dict[str, Any]) -> Any:
         stream = await self.pretrained_model.add_request(
             inputs=prompt,
             request_id=request_id,
-            params=SamplingParams(
-                ignore_eos=True,
-                detokenize=True,
-                seed=self.config.seed,
-                n=kwargs.get("num_return_sequences"),
-                max_tokens=kwargs.get("max_new_tokens"),
-                min_tokens=kwargs.get("min_new_tokens"),
-                use_beam_search=kwargs.get("num_beams") > 1,
-                logits_processors=kwargs.get("logits_processors", None),
-            ),
+            params=self.get_sampling_params(),
         )
 
         async for _ in stream:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ if USE_ROCM:
             "Please install amdsmi from https://github.com/ROCm/amdsmi to enable this feature."
         )
 
-
 EXTRAS_REQUIRE = {
     "quality": ["ruff"],
     "testing": ["pytest", "hydra-joblib-launcher"],


### PR DESCRIPTION
According to vllm upstream v0.6.2 [release note](https://github.com/vllm-project/vllm/releases/tag/v0.6.2), beam search has been soft deprecated and attribute `use_beam_search` in [SamplingParams](https://github.com/vllm-project/vllm/blob/v0.6.3/vllm/sampling_params.py#L173) has been removed in v0.6.3. To keep [vllm backend](https://github.com/huggingface/optimum-benchmark/blob/main/optimum_benchmark/backends/vllm/backend.py#L127 ) available without refactoring, setting vllm max version limit will help.