### PR TITLE
Feat: reimplement vllm backend beam search using logprobs

### DIFF
--- a/optimum_benchmark/backends/vllm/backend.py
+++ b/optimum_benchmark/backends/vllm/backend.py
@@ -143,7 +143,7 @@ class VLLMBackend(Backend[VLLMConfig]):
         stream = await self.pretrained_model.add_request(
             inputs=prompt,
             request_id=request_id,
-            params=self.get_sampling_params(),
+            params=self.get_sampling_params(kwargs),
         )
 
         async for _ in stream:


### PR DESCRIPTION
Vllm upstream changed `beam search` implementation. Corresponding updates should be made to get compatibility with the latest vllm.
Reimplement vllm backend beam search using logprobs according to huggingface [transformers implementation](https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/generation/beam_search.py#L534)
        