### PR TITLE
Add torchao to optimum as a pytorch backend configuration

### DIFF
--- a/examples/pytorch_llama.py
+++ b/examples/pytorch_llama.py
@@ -29,6 +29,11 @@ WEIGHTS_CONFIGS = {
         "quantization_scheme": "gptq",
         "quantization_config": {"bits": 4, "use_exllama ": True, "version": 2, "model_seqlen": 256},
     },
+    "torchao-int4wo-128": {
+        "torch_dtype": "bfloat16",
+        "quantization_scheme": "torchao",
+        "quantization_config": {"quant_type": "int4_weight_only", "group_size": 128},
+    }
 }
 
 

--- a/optimum_benchmark/backends/pytorch/backend.py
+++ b/optimum_benchmark/backends/pytorch/backend.py
@@ -16,6 +16,7 @@ from transformers import (
     TrainerState,
     TrainingArguments,
 )
+from transformers import TorchAoConfig
 
 from ...import_utils import is_deepspeed_available, is_torch_distributed_available, is_zentorch_available
 from ..base import Backend
@@ -323,6 +324,11 @@ class PyTorchBackend(Backend[PyTorchConfig]):
             self.quantization_config = BitsAndBytesConfig(
                 **dict(getattr(self.pretrained_config, "quantization_config", {}), **self.config.quantization_config)
             )
+        elif self.is_torchao_quantized:
+            self.logger.info("\t+ Processing TorchAO config")
+            self.quantization_config = TorchAoConfig(
+                **dict(getattr(self.pretrained_config, "quantization_config", {}), **self.config.quantization_config)
+            )
         else:
             raise ValueError(f"Quantization scheme {self.config.quantization_scheme} not recognized")
 
@@ -364,6 +370,13 @@ class PyTorchBackend(Backend[PyTorchConfig]):
         return self.config.quantization_scheme == "awq" or (
             hasattr(self.pretrained_config, "quantization_config")
             and self.pretrained_config.quantization_config.get("quant_method", None) == "awq"
+        )
+
+    @property
+    def is_torchao_quantized(self) -> bool:
+        return self.config.quantization_scheme == "torchao" or (
+            hasattr(self.pretrained_config, "quantization_config")
+            and self.pretrained_config.quantization_config.get("quant_method", None) == "torchao"
         )
 
     @property

--- a/optimum_benchmark/backends/pytorch/config.py
+++ b/optimum_benchmark/backends/pytorch/config.py
@@ -9,7 +9,7 @@ DEVICE_MAPS = ["auto", "sequential"]
 AMP_DTYPES = ["bfloat16", "float16"]
 TORCH_DTYPES = ["bfloat16", "float16", "float32", "auto"]
 
-QUANTIZATION_CONFIGS = {"bnb": {"llm_int8_threshold": 0.0}, "gptq": {}, "awq": {}}
+QUANTIZATION_CONFIGS = {"bnb": {"llm_int8_threshold": 0.0}, "gptq": {}, "awq": {}, "torchao": {}}
 
 
 @dataclass


### PR DESCRIPTION
Summary:
att.
for now we just added int4 weight only quantization, using `TorchAoConfig` from https://huggingface.co/docs/transformers/main/en/quantization/torchao

Test Plan:
python examples/pytorch_llama.py

gpt2 model

Base:
prefill: 9486.25 decode: 83.75

AWQ:
prefill: 9496.02 decode: 83.62

GPTQ
prefill: 9814.27 decode: 97.31

torchao int4wo
prefill: 10007.93 decode: 84.66

llama2

Base:
prefill: 2275.32 decode: 18.92

AWQ:
prefill: 2344.19 decode: 18.21

GPTQ:
prefill: 2881.87 decode: 26.47

torchao int4wo
prefill: 3035.82 decode: 24.51

Reviewers:

Subscribers:

Tasks:

Tags: