### PR TITLE
Avoid shell usage in system probes

### DIFF
--- a/optimum_benchmark/system_utils.py
+++ b/optimum_benchmark/system_utils.py
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import subprocess
+from pathlib import Path
 from typing import List, Optional
 
 import psutil
@@ -25,12 +26,11 @@ def get_cpu() -> Optional[str]:
         return platform.processor()
 
     elif platform.system() == "Darwin":
-        command = "sysctl -n machdep.cpu.brand_string"
-        return str(subprocess.check_output(command, shell=True).decode().strip())
+        command = ["sysctl", "-n", "machdep.cpu.brand_string"]
+        return subprocess.check_output(command, text=True).strip()
 
     elif platform.system() == "Linux":
-        command = "cat /proc/cpuinfo"
-        all_info = subprocess.check_output(command, shell=True).decode().strip()
+        all_info = Path("/proc/cpuinfo").read_text(encoding="utf-8").strip()
         for line in all_info.split("\n"):
             if "model name" in line:
                 return re.sub(".*model name.*:", "", line, 1)
@@ -45,14 +45,21 @@ def get_cpu_ram_mb():
 
 
 ## GPU related stuff
+def _command_succeeds(command: str) -> bool:
+    try:
+        return subprocess.call([command], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+    except FileNotFoundError:
+        return False
+
+
 @functools.lru_cache(maxsize=1)
 def is_nvidia_system():
-    return subprocess.call("nvidia-smi", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+    return _command_succeeds("nvidia-smi")
 
 
 @functools.lru_cache(maxsize=1)
 def is_rocm_system():
-    return subprocess.call("rocm-smi", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+    return _command_succeeds("rocm-smi")
 
 
 if is_nvidia_system() and is_pynvml_available():

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+repo_root = Path(__file__).resolve().parents[1]
+package = types.ModuleType("optimum_benchmark")
+package.__path__ = [str(repo_root / "optimum_benchmark")]
+sys.modules.setdefault("optimum_benchmark", package)
+
+import_utils = types.ModuleType("optimum_benchmark.import_utils")
+import_utils.is_amdsmi_available = lambda: False
+import_utils.is_pynvml_available = lambda: False
+import_utils.is_pyrsmi_available = lambda: False
+sys.modules["optimum_benchmark.import_utils"] = import_utils
+
+system_utils = importlib.import_module("optimum_benchmark.system_utils")
+
+
+def test_get_cpu_on_darwin_uses_sysctl_argv():
+    with (
+        patch.object(system_utils.platform, "system", return_value="Darwin"),
+        patch.object(system_utils.subprocess, "check_output", return_value="Apple M3 Max\n") as check_output,
+    ):
+        assert system_utils.get_cpu() == "Apple M3 Max"
+
+    check_output.assert_called_once_with(["sysctl", "-n", "machdep.cpu.brand_string"], text=True)
+
+
+def test_get_cpu_on_linux_reads_proc_cpuinfo():
+    cpuinfo = "processor\t: 0\nmodel name\t: Test CPU 123\n"
+
+    with (
+        patch.object(system_utils.platform, "system", return_value="Linux"),
+        patch.object(system_utils.Path, "read_text", return_value=cpuinfo) as read_text,
+    ):
+        assert system_utils.get_cpu() == " Test CPU 123"
+
+    read_text.assert_called_once_with(encoding="utf-8")
+
+
+def test_command_succeeds_uses_argv():
+    with patch.object(system_utils.subprocess, "call", return_value=0) as call:
+        assert system_utils._command_succeeds("nvidia-smi") is True
+
+    call.assert_called_once_with(
+        ["nvidia-smi"],
+        stdout=system_utils.subprocess.DEVNULL,
+        stderr=system_utils.subprocess.DEVNULL,
+    )
+
+
+def test_command_succeeds_handles_missing_binary():
+    with patch.object(system_utils.subprocess, "call", side_effect=FileNotFoundError):
+        assert system_utils._command_succeeds("nvidia-smi") is False


### PR DESCRIPTION
## Summary
- collect CPU information without shell commands
- run GPU vendor probes with argv lists and handle missing binaries explicitly
- add focused tests for Linux/macOS CPU probes and missing command handling

## Tests
- `PYTHONPATH=. uv run --no-project --with pytest --with psutil python -m pytest -q tests/test_system_utils.py`
- `python3 -m py_compile optimum_benchmark/system_utils.py tests/test_system_utils.py`
- `uv run --no-project --with ruff ruff check optimum_benchmark/system_utils.py tests/test_system_utils.py`
- `uv run --no-project --with ruff ruff format --check optimum_benchmark/system_utils.py tests/test_system_utils.py`
- `git diff --check`